### PR TITLE
Fixes: Type name update + findViewById not working

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,11 @@
+# v1.2.1
+# Fixed
+- An AndesMessage couldn't be found by its id due to a missing param in the constructor super() call.
+- Renamed `Highlight` state to `Neutral`.
+
+# Added
+- Enabled animateLayoutChanges() flag.
+
 # v1.2.0
 # Added
 - Allows changes of state, hierarchy and dismiss in runtime.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 # Fixed
 - An AndesMessage couldn't be found by its id due to a missing param in the constructor super() call.
 - Renamed `Highlight` state to `Neutral`.
+- Changed App Name of Demo App.
+- Main buttons of Demo App now have lateral margins.
 
 # Added
 - Enabled animateLayoutChanges() flag.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,8 @@
 # v1.2.1
 # Fixed
 - An AndesMessage couldn't be found by its id due to a missing param in the constructor super() call.
-- Renamed `Highlight` state to `Neutral`.
+- Renamed `Highlight` type to `Neutral`.
+- `States` are now `Types`.
 - Changed App Name of Demo App.
 - Main buttons of Demo App now have lateral margins.
 

--- a/components/src/main/java/com/mercadolibre/android/andesui/message/AndesMessage.kt
+++ b/components/src/main/java/com/mercadolibre/android/andesui/message/AndesMessage.kt
@@ -81,11 +81,11 @@ class AndesMessage : FrameLayout {
         throw IllegalStateException("Constructor without parameters in Andes Message is not allowed. You must provide some attributes.")
     }
 
-    constructor(context: Context, attrs: AttributeSet?) : super(context) {
+    constructor(context: Context, attrs: AttributeSet?) : super(context, attrs) {
         initAttrs(attrs)
     }
 
-    constructor(context: Context, attrs: AttributeSet?, defStyleAttr: Int) : super(context) {
+    constructor(context: Context, attrs: AttributeSet?, defStyleAttr: Int) : super(context, attrs) {
         initAttrs(attrs)
     }
 
@@ -222,7 +222,7 @@ class AndesMessage : FrameLayout {
 
     companion object {
         private val HIERARCHY_DEFAULT = AndesMessageHierarchy.LOUD
-        private val STATE_DEFAULT = AndesMessageState.HIGHLIGHT
+        private val STATE_DEFAULT = AndesMessageState.NEUTRAL
         private val TITLE_DEFAULT = null
         private const val IS_DISMISSIBLE_DEFAULT = false
     }

--- a/components/src/main/java/com/mercadolibre/android/andesui/message/AndesMessage.kt
+++ b/components/src/main/java/com/mercadolibre/android/andesui/message/AndesMessage.kt
@@ -15,7 +15,7 @@ import com.mercadolibre.android.andesui.message.factory.AndesMessageAttrsParser
 import com.mercadolibre.android.andesui.message.factory.AndesMessageConfiguration
 import com.mercadolibre.android.andesui.message.factory.AndesMessageConfigurationFactory
 import com.mercadolibre.android.andesui.message.hierarchy.AndesMessageHierarchy
-import com.mercadolibre.android.andesui.message.state.AndesMessageState
+import com.mercadolibre.android.andesui.message.state.AndesMessageType
 
 class AndesMessage : FrameLayout {
 
@@ -29,12 +29,12 @@ class AndesMessage : FrameLayout {
             setupColorComponents(createConfig())
         }
     /**
-     * Getter and setter for [state].
+     * Getter and setter for [type].
      */
-    var state: AndesMessageState
-        get() = andesMessageAttrs.andesMessageState
+    var type: AndesMessageType
+        get() = andesMessageAttrs.andesMessageType
         set(value) {
-            andesMessageAttrs = andesMessageAttrs.copy(andesMessageState = value)
+            andesMessageAttrs = andesMessageAttrs.copy(andesMessageType = value)
             setupColorComponents(createConfig())
         }
 
@@ -92,12 +92,12 @@ class AndesMessage : FrameLayout {
     @Suppress("unused")
     constructor(context: Context,
                 hierarchy: AndesMessageHierarchy = HIERARCHY_DEFAULT,
-                state: AndesMessageState = STATE_DEFAULT,
+                type: AndesMessageType = STATE_DEFAULT,
                 body: String,
                 title: String? = TITLE_DEFAULT,
                 isDismissable: Boolean = IS_DISMISSIBLE_DEFAULT
     ) : super(context) {
-        initAttrs(hierarchy, state, body, title, isDismissable)
+        initAttrs(hierarchy, type, body, title, isDismissable)
     }
 
     /**
@@ -112,8 +112,8 @@ class AndesMessage : FrameLayout {
     }
 
 
-    private fun initAttrs(hierarchy: AndesMessageHierarchy, state: AndesMessageState, body: String, title: String?, isDismissable: Boolean) {
-        andesMessageAttrs = AndesMessageAttrs(hierarchy, state, body, title, isDismissable)
+    private fun initAttrs(hierarchy: AndesMessageHierarchy, type: AndesMessageType, body: String, title: String?, isDismissable: Boolean) {
+        andesMessageAttrs = AndesMessageAttrs(hierarchy, type, body, title, isDismissable)
         val config = AndesMessageConfigurationFactory.create(context, andesMessageAttrs)
         setupComponents(config)
     }
@@ -222,7 +222,7 @@ class AndesMessage : FrameLayout {
 
     companion object {
         private val HIERARCHY_DEFAULT = AndesMessageHierarchy.LOUD
-        private val STATE_DEFAULT = AndesMessageState.NEUTRAL
+        private val STATE_DEFAULT = AndesMessageType.NEUTRAL
         private val TITLE_DEFAULT = null
         private const val IS_DISMISSIBLE_DEFAULT = false
     }

--- a/components/src/main/java/com/mercadolibre/android/andesui/message/factory/AndesMessageAttrsParser.kt
+++ b/components/src/main/java/com/mercadolibre/android/andesui/message/factory/AndesMessageAttrsParser.kt
@@ -23,7 +23,7 @@ internal object AndesMessageAttrsParser {
     private const val ANDES_MESSAGE_HIERARCHY_LOUD = "1000"
     private const val ANDES_MESSAGE_HIERARCHY_QUIET = "1001"
 
-    private const val ANDES_MESSAGE_STATE_HIGHLIGHT = "2000"
+    private const val ANDES_MESSAGE_STATE_NEUTRAL = "2000"
     private const val ANDES_MESSAGE_STATE_SUCCESS = "2001"
     private const val ANDES_MESSAGE_STATE_WARNING = "2002"
     private const val ANDES_MESSAGE_STATE_ERROR = "2003"
@@ -38,11 +38,11 @@ internal object AndesMessageAttrsParser {
         }
 
         val state = when (typedArray.getString(R.styleable.AndesMessage_andesMessageState)) {
-            ANDES_MESSAGE_STATE_HIGHLIGHT -> AndesMessageState.HIGHLIGHT
+            ANDES_MESSAGE_STATE_NEUTRAL -> AndesMessageState.NEUTRAL
             ANDES_MESSAGE_STATE_SUCCESS -> AndesMessageState.SUCCESS
             ANDES_MESSAGE_STATE_WARNING -> AndesMessageState.WARNING
             ANDES_MESSAGE_STATE_ERROR -> AndesMessageState.ERROR
-            else -> AndesMessageState.HIGHLIGHT
+            else -> AndesMessageState.NEUTRAL
         }
 
         return AndesMessageAttrs(

--- a/components/src/main/java/com/mercadolibre/android/andesui/message/factory/AndesMessageAttrsParser.kt
+++ b/components/src/main/java/com/mercadolibre/android/andesui/message/factory/AndesMessageAttrsParser.kt
@@ -4,13 +4,13 @@ import android.content.Context
 import android.util.AttributeSet
 import com.mercadolibre.android.andesui.R
 import com.mercadolibre.android.andesui.message.hierarchy.AndesMessageHierarchy
-import com.mercadolibre.android.andesui.message.state.AndesMessageState
+import com.mercadolibre.android.andesui.message.state.AndesMessageType
 
 /**
  * The data class that contains the public components of the message.
  */
 internal data class AndesMessageAttrs(val andesMessageHierarchy: AndesMessageHierarchy,
-                                      val andesMessageState: AndesMessageState,
+                                      val andesMessageType: AndesMessageType,
                                       val body: String,
                                       val title: String?,
                                       val isDismissable: Boolean)
@@ -37,17 +37,17 @@ internal object AndesMessageAttrsParser {
             else -> AndesMessageHierarchy.LOUD
         }
 
-        val state = when (typedArray.getString(R.styleable.AndesMessage_andesMessageState)) {
-            ANDES_MESSAGE_STATE_NEUTRAL -> AndesMessageState.NEUTRAL
-            ANDES_MESSAGE_STATE_SUCCESS -> AndesMessageState.SUCCESS
-            ANDES_MESSAGE_STATE_WARNING -> AndesMessageState.WARNING
-            ANDES_MESSAGE_STATE_ERROR -> AndesMessageState.ERROR
-            else -> AndesMessageState.NEUTRAL
+        val state = when (typedArray.getString(R.styleable.AndesMessage_andesMessageType)) {
+            ANDES_MESSAGE_STATE_NEUTRAL -> AndesMessageType.NEUTRAL
+            ANDES_MESSAGE_STATE_SUCCESS -> AndesMessageType.SUCCESS
+            ANDES_MESSAGE_STATE_WARNING -> AndesMessageType.WARNING
+            ANDES_MESSAGE_STATE_ERROR -> AndesMessageType.ERROR
+            else -> AndesMessageType.NEUTRAL
         }
 
         return AndesMessageAttrs(
                 andesMessageHierarchy = hierarchy,
-                andesMessageState = state,
+                andesMessageType = state,
                 body = typedArray.getString(R.styleable.AndesMessage_andesMessageBodyText) ?: throw IllegalArgumentException("Body is a mandatory parameter"),
                 title = typedArray.getString(R.styleable.AndesMessage_andesMessageTitleText),
                 isDismissable = typedArray.getBoolean(R.styleable.AndesMessage_andesMessageDismissable, false)

--- a/components/src/main/java/com/mercadolibre/android/andesui/message/factory/AndesMessageConfigurationFactory.kt
+++ b/components/src/main/java/com/mercadolibre/android/andesui/message/factory/AndesMessageConfigurationFactory.kt
@@ -32,9 +32,9 @@ internal object AndesMessageConfigurationFactory {
     fun create(context: Context, andesMessageAttrs: AndesMessageAttrs): AndesMessageConfiguration {
         return with(andesMessageAttrs) {
             AndesMessageConfiguration(
-                    iconBackgroundColor = resolveIconBackgroundColor(andesMessageState.state, context),
-                    backgroundColor = resolveBackgroundColor(andesMessageHierarchy.hierarchy, andesMessageState.state, context),
-                    pipeColor = resolvePipeColor(andesMessageState.state, context),
+                    iconBackgroundColor = resolveIconBackgroundColor(andesMessageType.state, context),
+                    backgroundColor = resolveBackgroundColor(andesMessageHierarchy.hierarchy, andesMessageType.state, context),
+                    pipeColor = resolvePipeColor(andesMessageType.state, context),
                     textColor = resolveTextColor(andesMessageHierarchy.hierarchy, context),
                     titleText = title,
                     bodyText = body,
@@ -43,7 +43,7 @@ internal object AndesMessageConfigurationFactory {
                     bodySize = resolveBodySize(context),
                     titleTypeface = resolveTitleTypeface(andesMessageHierarchy.hierarchy, context),
                     bodyTypeface = resolveBodyTypeface(andesMessageHierarchy.hierarchy, context),
-                    icon = resolveIcon(andesMessageState.state, andesMessageHierarchy.hierarchy, context),
+                    icon = resolveIcon(andesMessageType.state, andesMessageHierarchy.hierarchy, context),
                     isDismissable = isDismissable,
                     dismissableIcon = resolveDismissableIcon(andesMessageHierarchy.hierarchy, context),
                     dismissableIconColor = resolveDismissableIconColor(andesMessageHierarchy.hierarchy, context),

--- a/components/src/main/java/com/mercadolibre/android/andesui/message/state/AndesMessageState.kt
+++ b/components/src/main/java/com/mercadolibre/android/andesui/message/state/AndesMessageState.kt
@@ -9,7 +9,7 @@ package com.mercadolibre.android.andesui.message.state
  * @property state Possible styles that an [AndesMessage] may take.
  */
 enum class AndesMessageState {
-    HIGHLIGHT,
+    NEUTRAL,
     SUCCESS,
     WARNING,
     ERROR;
@@ -18,7 +18,7 @@ enum class AndesMessageState {
 
     private fun getAndesMessageHierarchy(): AndesMessageStateInterface {
         return when (this) {
-            HIGHLIGHT -> AndesHighlightMessageState
+            NEUTRAL -> AndesNeutralMessageState
             SUCCESS -> AndesSuccessMessageState
             WARNING -> AndesWarningMessageState
             ERROR -> AndesErrorMessageState

--- a/components/src/main/java/com/mercadolibre/android/andesui/message/state/AndesMessageStateInterface.kt
+++ b/components/src/main/java/com/mercadolibre/android/andesui/message/state/AndesMessageStateInterface.kt
@@ -27,7 +27,7 @@ internal sealed class AndesMessageStateInterface {
     fun iconBackgroundColor(context: Context) = secondaryColor(context)
 }
 
-internal object AndesHighlightMessageState : AndesMessageStateInterface() {
+internal object AndesNeutralMessageState : AndesMessageStateInterface() {
     override fun primaryColor(context: Context) = ContextCompat.getColor(context, R.color.andesui_message_highlight_primary)
     override fun secondaryColor(context: Context) = ContextCompat.getColor(context, R.color.andesui_message_highlight_primary_dark)
     override fun icon(context: Context, hierarchy: AndesMessageHierarchyInterface) = buildColoredCircularShapeWithIconDrawable(

--- a/components/src/main/java/com/mercadolibre/android/andesui/message/state/AndesMessageType.kt
+++ b/components/src/main/java/com/mercadolibre/android/andesui/message/state/AndesMessageType.kt
@@ -8,7 +8,7 @@ package com.mercadolibre.android.andesui.message.state
  *
  * @property state Possible styles that an [AndesMessage] may take.
  */
-enum class AndesMessageState {
+enum class AndesMessageType {
     NEUTRAL,
     SUCCESS,
     WARNING,

--- a/components/src/main/res/message/layout/andesui_layout_message.xml
+++ b/components/src/main/res/message/layout/andesui_layout_message.xml
@@ -3,14 +3,15 @@
     xmlns:app="http://schemas.android.com/apk/res-auto"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
-    app:cardCornerRadius="6dp"
+    app:cardCornerRadius="@dimen/andesui_message_corner_radius"
     app:cardElevation="0dp"
     app:cardPreventCornerOverlap="true">
 
     <android.support.constraint.ConstraintLayout
         android:id="@+id/andesui_message_container"
         android:layout_width="match_parent"
-        android:layout_height="match_parent">
+        android:layout_height="match_parent"
+        android:animateLayoutChanges="true">
 
         <TextView
             android:id="@+id/andesui_title"

--- a/components/src/main/res/message/values/attrs.xml
+++ b/components/src/main/res/message/values/attrs.xml
@@ -7,7 +7,7 @@
         </attr>
 
         <attr name="andesMessageState">
-            <enum name="highlight" value="2000" />
+            <enum name="neutral" value="2000" />
             <enum name="success" value="2001" />
             <enum name="warning" value="2002" />
             <enum name="error" value="2003" />

--- a/components/src/main/res/message/values/attrs.xml
+++ b/components/src/main/res/message/values/attrs.xml
@@ -6,7 +6,7 @@
             <enum name="quiet" value="1001" />
         </attr>
 
-        <attr name="andesMessageState">
+        <attr name="andesMessageType">
             <enum name="neutral" value="2000" />
             <enum name="success" value="2001" />
             <enum name="warning" value="2002" />

--- a/components/src/main/res/message/values/dimens_message.xml
+++ b/components/src/main/res/message/values/dimens_message.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
-    <dimen name="andesui_message_corner_radius">0dp</dimen>
+    <dimen name="andesui_message_corner_radius">6dp</dimen>
     <dimen name="andesui_message_pipe_corner_radius">0dp</dimen>
     <dimen name="andesui_message_left_corner_radius">0dp</dimen>
 

--- a/demoapp/src/main/java/com/mercadolibre/android/andesui/demoapp/MessageShowcaseActivity.kt
+++ b/demoapp/src/main/java/com/mercadolibre/android/andesui/demoapp/MessageShowcaseActivity.kt
@@ -14,7 +14,7 @@ import com.mercadolibre.android.andesui.demoapp.PageIndicator
 import com.mercadolibre.android.andesui.demoapp.R
 import com.mercadolibre.android.andesui.message.AndesMessage
 import com.mercadolibre.android.andesui.message.hierarchy.AndesMessageHierarchy
-import com.mercadolibre.android.andesui.message.state.AndesMessageState
+import com.mercadolibre.android.andesui.message.state.AndesMessageType
 
 class MessageShowcaseActivity : AppCompatActivity() {
     override fun onCreate(savedInstanceState: Bundle?) {
@@ -60,7 +60,7 @@ class MessageShowcaseActivity : AppCompatActivity() {
                 val hour = System.currentTimeMillis().toString()
                 message.title = ("The current millis are: $hour")
                 message.hierarchy = (AndesMessageHierarchy.LOUD)
-                message.state = (AndesMessageState.SUCCESS)
+                message.type = (AndesMessageType.SUCCESS)
                 message.isDismissable = false
                 message.body = "I insist. Current millis are: $hour"
             }

--- a/demoapp/src/main/java/com/mercadolibre/android/andesui/demoapp/MessageShowcaseActivity.kt
+++ b/demoapp/src/main/java/com/mercadolibre/android/andesui/demoapp/MessageShowcaseActivity.kt
@@ -8,7 +8,6 @@ import android.support.v7.app.AppCompatActivity
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
-import android.widget.LinearLayout
 import android.widget.ScrollView
 import com.mercadolibre.android.andesui.button.AndesButton
 import com.mercadolibre.android.andesui.demoapp.PageIndicator
@@ -26,18 +25,6 @@ class MessageShowcaseActivity : AppCompatActivity() {
         viewPager.adapter = AndesShowcasePagerAdapter(this)
         val indicator = findViewById<PageIndicator>(R.id.page_indicator)
         indicator.attach(viewPager)
-
-        val adapter = viewPager.adapter as AndesShowcasePagerAdapter
-        addMessage(adapter.views[0])
-    }
-
-    private fun addMessage(container: View) {
-        //TODO Create a Message view
-
-        val linearLoud = container.findViewById<LinearLayout>(R.id.andes_loud_container)
-
-        //TODO Add messages to the linear layout
-        //linearLoud.addView(andesMessage)
     }
 
     class AndesShowcasePagerAdapter(private val context: Context) : PagerAdapter() {
@@ -69,12 +56,13 @@ class MessageShowcaseActivity : AppCompatActivity() {
             val button = layoutMessages.findViewById<AndesButton>(R.id.button)
 
             button.setOnClickListener {
-                val message = (layoutMessages.getChildAt(0) as LinearLayout).getChildAt(2) as AndesMessage
-                message.title =("Soy un titulo muy largo y hago muchas cosas como setear la hora " +  System.currentTimeMillis())
+                val message = layoutMessages.findViewById<AndesMessage>(R.id.message_loud)
+                val hour = System.currentTimeMillis().toString()
+                message.title = ("The current millis are: $hour")
                 message.hierarchy = (AndesMessageHierarchy.LOUD)
                 message.state = (AndesMessageState.SUCCESS)
                 message.isDismissable = false
-                message.body = "cambie mi body"
+                message.body = "I insist. Current millis are: $hour"
             }
 
             return listOf<View>(layoutMessages)

--- a/demoapp/src/main/res/layout/andesui_demoapp_main.xml
+++ b/demoapp/src/main/res/layout/andesui_demoapp_main.xml
@@ -10,9 +10,10 @@
         android:id="@+id/andesui_buttons"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
+        android:layout_marginLeft="@dimen/button_margin_vertical"
+        android:layout_marginRight="@dimen/button_margin_vertical"
         android:layout_marginBottom="@dimen/button_margin_vertical"
         app:andesButtonHierarchy="loud"
-        app:andesButtonLeftIconCustom="@drawable/andesui_icon"
         app:andesButtonSize="large"
         app:andesButtonText="@string/andes_button_showcase" />
 
@@ -20,8 +21,9 @@
         android:id="@+id/andesui_messages"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
+        android:layout_marginLeft="@dimen/button_margin_vertical"
+        android:layout_marginRight="@dimen/button_margin_vertical"
         app:andesButtonHierarchy="loud"
-        app:andesButtonLeftIconCustom="@drawable/andesui_icon"
         app:andesButtonSize="large"
         app:andesButtonText="@string/andes_message_showcase" />
 

--- a/demoapp/src/main/res/layout/andesui_message_showcase.xml
+++ b/demoapp/src/main/res/layout/andesui_message_showcase.xml
@@ -7,6 +7,7 @@
     <LinearLayout
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
+        android:animateLayoutChanges="true"
         android:orientation="vertical">
 
         <TextView
@@ -46,18 +47,18 @@
             android:layout_marginBottom="@dimen/button_margin_vertical"
             app:andesMessageBodyText="@string/body_text"
             app:andesMessageHierarchy="loud"
-            app:andesMessageState="highlight"
+            app:andesMessageState="neutral"
             app:andesMessageTitleText="@string/title_text" />
 
         <com.mercadolibre.android.andesui.message.AndesMessage
+            android:id="@+id/message_loud"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
             android:layout_margin="@dimen/button_margin_vertical"
             android:layout_marginBottom="@dimen/button_margin_vertical"
             app:andesMessageBodyText="@string/body_text"
             app:andesMessageHierarchy="loud"
-            app:andesMessageState="error"
-             />
+            app:andesMessageState="error" />
 
         <com.mercadolibre.android.andesui.button.AndesButton
             android:id="@+id/button"

--- a/demoapp/src/main/res/layout/andesui_message_showcase.xml
+++ b/demoapp/src/main/res/layout/andesui_message_showcase.xml
@@ -26,7 +26,7 @@
             app:andesMessageBodyText="@string/body_text"
             app:andesMessageDismissable="true"
             app:andesMessageHierarchy="loud"
-            app:andesMessageState="success"
+            app:andesMessageType="success"
             app:andesMessageTitleText="@string/title_text" />
 
         <com.mercadolibre.android.andesui.message.AndesMessage
@@ -37,7 +37,7 @@
             app:andesMessageBodyText="@string/body_text"
             app:andesMessageDismissable="true"
             app:andesMessageHierarchy="quiet"
-            app:andesMessageState="warning"
+            app:andesMessageType="warning"
             app:andesMessageTitleText="@string/title_text" />
 
         <com.mercadolibre.android.andesui.message.AndesMessage
@@ -47,7 +47,7 @@
             android:layout_marginBottom="@dimen/button_margin_vertical"
             app:andesMessageBodyText="@string/body_text"
             app:andesMessageHierarchy="loud"
-            app:andesMessageState="neutral"
+            app:andesMessageType="neutral"
             app:andesMessageTitleText="@string/title_text" />
 
         <com.mercadolibre.android.andesui.message.AndesMessage
@@ -58,7 +58,7 @@
             android:layout_marginBottom="@dimen/button_margin_vertical"
             app:andesMessageBodyText="@string/body_text"
             app:andesMessageHierarchy="loud"
-            app:andesMessageState="error" />
+            app:andesMessageType="error" />
 
         <com.mercadolibre.android.andesui.button.AndesButton
             android:id="@+id/button"

--- a/demoapp/src/main/res/values/strings.xml
+++ b/demoapp/src/main/res/values/strings.xml
@@ -1,5 +1,5 @@
 <resources>
-    <string name="andesui_demoapp_app_name">Andes UI - Demo App</string>
+    <string name="andesui_demoapp_app_name">Andes UI</string>
     <string name="loud_large_button">Loud Large Button</string>
     <string name="loud_medium_button">Loud Medium Button</string>
     <string name="loud_small_button">Loud Small Button</string>

--- a/gradle.properties
+++ b/gradle.properties
@@ -34,7 +34,7 @@ libraryGroupId=com.mercadolibre.android.andesui
 # IMPORTANT: We're using http://semver.org/ for all Android projects, please remember to follow this convention.
 # IMPORTANT: The version will be THE SAME for all modules.
 # For libraryVersion do NOT add a qualifier to this version like LOCAL/EXPERIMENTAL (it'll be added automatically!)
-libraryVersion=1.2.0
+libraryVersion=1.2.1
 
 ##################################################################################
 # Project setup


### PR DESCRIPTION
## Motivation
An AndesMessage couldn't be found by its id (even if you specify one id via XML code).

## Description
- We were calling super(context) instead of super(context, attrs), so ID was getting null and then a random ID was assigned to the AndesMessage: Impossible to found.

- UX team said that Highlight was not the right name for one of the states. It should be called Neutral. We had aligned this naming :)

- We had some free time to play with Android APIs so we decided to add `animateLayoutChanges` flag.

## Affected component
AndesMessage

## Frontify component link
https://company-161429.frontify.com/d/kxHCRixezmfK/n-a#/componentes/message

## Screenshots
![Screenshot_1580330037](https://user-images.githubusercontent.com/35068259/73395100-96887980-42bd-11ea-9d7a-75649d028518.png)

![GIPHY](https://user-images.githubusercontent.com/35068259/73394190-e49c7d80-42bb-11ea-95c3-9c6726527220.gif)

## Checks
Are you sure you followed all those steps? In such case, let's say with me "I solemnly declare that ...":
- [X] I have coded an example inside the Demo App,
- [ ] I have added proper tests,
- [X] I have modified the [Changelog](https://github.com/mercadolibre/...) file,
- [ ] I have updated GitHub wiki,
- [X] I have the explicit approval of one or more members of the UX Team,
- [X] I have updated the version in gradle.properties file.

## Change type
This is easy, let us know what this code is about:
- [ ] This code adds a new component
- [X] This code includes improvements to an existent component
- [ ] This code improves or modifies ONLY the Demo App.