### PR TITLE
textfield right and left component

### DIFF
--- a/components/src/main/java/com/mercadolibre/android/andesui/textfield/AndesTextfield.kt
+++ b/components/src/main/java/com/mercadolibre/android/andesui/textfield/AndesTextfield.kt
@@ -74,6 +74,7 @@ class AndesTextfield : ConstraintLayout {
         get() = andesTextfieldAttrs.state
         set(value) {
             andesTextfieldAttrs = andesTextfieldAttrs.copy(state = value)
+            setupColorComponents(createConfig())
         }
 
     var leftContent: AndesTextfieldLeftContent?

--- a/components/src/main/java/com/mercadolibre/android/andesui/textfield/AndesTextfield.kt
+++ b/components/src/main/java/com/mercadolibre/android/andesui/textfield/AndesTextfield.kt
@@ -4,18 +4,15 @@ import android.content.Context
 import android.graphics.drawable.BitmapDrawable
 import android.support.constraint.ConstraintLayout
 import android.util.AttributeSet
-import android.util.Log
 import android.view.LayoutInflater
 import android.view.View
 import android.widget.EditText
 import android.widget.FrameLayout
 import android.widget.TextView
 import com.facebook.drawee.view.SimpleDraweeView
-import com.mercadolibre.android.andesui.BuildConfig
 import com.mercadolibre.android.andesui.R
 import com.mercadolibre.android.andesui.button.AndesButton
 import com.mercadolibre.android.andesui.color.toAndesColor
-import com.mercadolibre.android.andesui.color.toColor
 import com.mercadolibre.android.andesui.icons.OfflineIconProvider
 import com.mercadolibre.android.andesui.textfield.content.AndesTextfieldLeftContent
 import com.mercadolibre.android.andesui.textfield.content.AndesTextfieldRightContent
@@ -65,12 +62,14 @@ class AndesTextfield : ConstraintLayout {
         get() = andesTextfieldAttrs.leftContent
         set(value) {
             andesTextfieldAttrs = andesTextfieldAttrs.copy(leftContent = value)
+            setupLeftComponent(createConfig())
         }
 
     var rightContent: AndesTextfieldRightContent?
         get() = andesTextfieldAttrs.rightContent
         set(value) {
             andesTextfieldAttrs = andesTextfieldAttrs.copy(rightContent = value)
+            setupRightComponent(createConfig())
         }
 
     private lateinit var andesTextfieldAttrs: AndesTextfieldAttrs
@@ -119,7 +118,6 @@ class AndesTextfield : ConstraintLayout {
         setupErrorIcon(config)
         setupLeftComponent(config)
         setupRightComponent(config)
-        setupClear()
     }
 
     /**
@@ -203,6 +201,7 @@ class AndesTextfield : ConstraintLayout {
         if (config.rightComponent != null) {
             rightComponent.removeAllViews()
             rightComponent.addView(config.rightComponent)
+            setupClear()
 
             val params = rightComponent.layoutParams as ConstraintLayout.LayoutParams
             params.marginStart = config.rightComponentLeftMargin!!
@@ -224,74 +223,46 @@ class AndesTextfield : ConstraintLayout {
     }
 
     fun setupAction(text: String, onClickListener: OnClickListener) {
-        if (rightContent == AndesTextfieldRightContent.ACTION) {
-            val action: AndesButton = rightComponent.getChildAt(0) as AndesButton
-            action.text = text
-            action.setOnClickListener(onClickListener)
-        } else
-            when {
-                BuildConfig.DEBUG -> throw IllegalStateException("Cannot setup an action without choosing the correct content")
-                else -> Log.d("AndesTextfield", "Cannot setup an action without choosing the correct content")
-            }
+        rightContent = AndesTextfieldRightContent.ACTION
+        val action: AndesButton = rightComponent.getChildAt(0) as AndesButton
+        action.text = text
+        action.setOnClickListener(onClickListener)
+
     }
 
     fun setupRightIcon(iconPath: String) {
-        if (rightContent == AndesTextfieldRightContent.ICON) {
-            val clear: SimpleDraweeView = rightComponent.getChildAt(0) as SimpleDraweeView
-            clear.setImageDrawable(buildColoredBitmapDrawable(
-                    OfflineIconProvider(context).loadIcon(iconPath) as BitmapDrawable,
-                    context,
-                    R.color.andes_gray_800.toAndesColor())
-            )
-        } else
-            when {
-                BuildConfig.DEBUG -> throw IllegalStateException("Cannot setup a right icon without choosing the correct content")
-                else -> Log.d("AndesTextfield", "Cannot setup a right icon without choosing the correct content")
-            }
+        rightContent = AndesTextfieldRightContent.ICON
+        val rightIcon: SimpleDraweeView = rightComponent.getChildAt(0) as SimpleDraweeView
+        rightIcon.setImageDrawable(buildColoredBitmapDrawable(
+                OfflineIconProvider(context).loadIcon(iconPath) as BitmapDrawable,
+                context,
+                R.color.andes_gray_800.toAndesColor())
+        )
     }
 
     fun setupLeftIcon(iconPath: String) {
-        if (leftContent == AndesTextfieldLeftContent.ICON) {
-            val clear: SimpleDraweeView = leftComponent.getChildAt(0) as SimpleDraweeView
-            clear.setImageDrawable(buildColoredBitmapDrawable(
-                    OfflineIconProvider(context).loadIcon(iconPath) as BitmapDrawable,
-                    context,
-                    R.color.andes_gray_450.toAndesColor())
-            )
-        } else
-            when {
-                BuildConfig.DEBUG -> throw IllegalStateException("Cannot setup a left icon without choosing the correct content")
-                else -> Log.d("AndesTextfield", "Cannot setup a left icon without choosing the correct content")
-            }
+        leftContent = AndesTextfieldLeftContent.ICON
+        val leftIcon: SimpleDraweeView = leftComponent.getChildAt(0) as SimpleDraweeView
+        leftIcon.setImageDrawable(buildColoredBitmapDrawable(
+                OfflineIconProvider(context).loadIcon(iconPath) as BitmapDrawable,
+                context,
+                R.color.andes_gray_450.toAndesColor())
+        )
+
+    }
+
+    fun setupPrefix(text: String) {
+        leftContent = AndesTextfieldLeftContent.PREFIX
+        val prefix: TextView = leftComponent.getChildAt(0) as TextView
+        prefix.text = text
     }
 
 
-
-    fun setupPrefix(text: String){
-        if (leftContent == AndesTextfieldLeftContent.PREFIX){
-            val prefix : TextView = leftComponent.getChildAt(0) as TextView
-            prefix.setTextColor(R.color.andes_gray_450.toColor(context))
-            prefix.text = text
-
-        }
-        else
-            when {
-                BuildConfig.DEBUG -> throw IllegalStateException("Cannot setup a prefix without choosing the correct content")
-                else -> Log.d("AndesTextfield", "Cannot setup a prefix without choosing the correct content")
-            }
-    }
-
-
-    fun setupSuffix(text: String){
-        if (rightContent == AndesTextfieldRightContent.SUFFIX){
-            val suffix : TextView = leftComponent.getChildAt(0) as TextView
-            suffix.setTextColor(R.color.andes_gray_450.toColor(context))
+    fun setupSuffix(text: String) {
+        rightContent = AndesTextfieldRightContent.SUFFIX
+            val suffix: TextView = leftComponent.getChildAt(0) as TextView
             suffix.text = text
-        }
-        else
-            when {
-                BuildConfig.DEBUG -> throw IllegalStateException("Cannot setup a prefix without choosing the correct content")
-                else -> Log.d("AndesTextfield", "Cannot setup a prefix without choosing the correct content")
-            }
     }
+
+    private fun createConfig() = AndesTextfieldConfigurationFactory.create(context, andesTextfieldAttrs)
 }

--- a/components/src/main/java/com/mercadolibre/android/andesui/textfield/content/AndesTexfieldContent.kt
+++ b/components/src/main/java/com/mercadolibre/android/andesui/textfield/content/AndesTexfieldContent.kt
@@ -1,0 +1,51 @@
+package com.mercadolibre.android.andesui.textfield.content
+
+/**
+ * Utility class that does two things: Defines the possible states an [AndesTextfield] can take because it's an enum, as you can see.
+ * But as a bonus it gives you the proper implementation so you don't have to make any mapping.
+ *
+ * You ask me with, let's say 'ENABLED', and then I'll give you a proper implementation of that content.
+ *
+ * @property content Possible contents that an [AndesTextfield] may take.
+ */
+
+enum class AndesTextfieldLeftContent {
+    PREFIX,
+    ICON;
+
+    internal val leftContent get() = getAndesTexfieldLeftContent()
+
+    private fun getAndesTexfieldLeftContent(): AndesTextfieldContentInterface {
+        return when (this) {
+            PREFIX -> AndesPrefixTextfieldContent
+            ICON -> AndesIconTextfieldContent
+        }
+    }
+}
+
+enum class AndesTextfieldRightContent {
+    SUFFIX,
+    ICON,
+    TOOLTIP,
+    VALIDATED,
+    CLEAR,
+    ACTION,
+    INDETERMINATE,
+    CHECKBOX;
+
+    internal val rightContent get() = getAndesTexfieldRightContent()
+
+    private fun getAndesTexfieldRightContent(): AndesTextfieldContentInterface {
+        return when (this) {
+            SUFFIX -> AndesSuffixTextfieldContent
+            ICON -> AndesIconTextfieldContent
+            TOOLTIP -> AndesTooltipTextfieldContent
+            VALIDATED -> AndesValidatedTextfieldContent
+            CLEAR -> AndesClearTextfieldContent
+            ACTION -> AndesActionTextfieldContent
+            INDETERMINATE -> AndesIndeterminateTextfieldContent
+            CHECKBOX -> AndesCheckboxTextfieldContent
+        }
+    }
+}
+

--- a/components/src/main/java/com/mercadolibre/android/andesui/textfield/content/AndesTextfieldContentInterface.kt
+++ b/components/src/main/java/com/mercadolibre/android/andesui/textfield/content/AndesTextfieldContentInterface.kt
@@ -34,7 +34,7 @@ internal object AndesSuffixTextfieldContent : AndesTextfieldContentInterface() {
     override fun component(context: Context): TextView {
         val suffix  = TextView(context)
         suffix.setTextColor(R.color.andes_gray_450.toColor(context))
-        suffix.text = "Suffix"
+        suffix.text = context.getString(R.string.andes_suffix_hint)
         suffix.typeface = context.getFontOrDefault(R.font.andes_font_regular)
         return suffix
     }
@@ -49,7 +49,7 @@ internal object AndesPrefixTextfieldContent : AndesTextfieldContentInterface() {
     override fun component(context: Context): TextView {
         val prefix  = TextView(context)
         prefix.setTextColor(R.color.andes_gray_450.toColor(context))
-        prefix.text = "Prefix"
+        prefix.text = context.getString(R.string.andes_prefix_hint)
         prefix.typeface = context.getFontOrDefault(R.font.andes_font_regular)
         return prefix
     }

--- a/components/src/main/java/com/mercadolibre/android/andesui/textfield/content/AndesTextfieldContentInterface.kt
+++ b/components/src/main/java/com/mercadolibre/android/andesui/textfield/content/AndesTextfieldContentInterface.kt
@@ -12,6 +12,7 @@ import com.mercadolibre.android.andesui.button.size.AndesButtonSize
 import com.mercadolibre.android.andesui.color.toAndesColor
 import com.mercadolibre.android.andesui.color.toColor
 import com.mercadolibre.android.andesui.icons.OfflineIconProvider
+import com.mercadolibre.android.andesui.typeface.getFontOrDefault
 import com.mercadolibre.android.andesui.utils.buildColoredBitmapDrawable
 
 /**
@@ -34,6 +35,7 @@ internal object AndesSuffixTextfieldContent : AndesTextfieldContentInterface() {
         val suffix  = TextView(context)
         suffix.setTextColor(R.color.andes_gray_450.toColor(context))
         suffix.text = "Suffix"
+        suffix.typeface = context.getFontOrDefault(R.font.andes_font_regular)
         return suffix
     }
 }
@@ -48,6 +50,7 @@ internal object AndesPrefixTextfieldContent : AndesTextfieldContentInterface() {
         val prefix  = TextView(context)
         prefix.setTextColor(R.color.andes_gray_450.toColor(context))
         prefix.text = "Prefix"
+        prefix.typeface = context.getFontOrDefault(R.font.andes_font_regular)
         return prefix
     }
 }

--- a/components/src/main/java/com/mercadolibre/android/andesui/textfield/content/AndesTextfieldContentInterface.kt
+++ b/components/src/main/java/com/mercadolibre/android/andesui/textfield/content/AndesTextfieldContentInterface.kt
@@ -1,0 +1,129 @@
+package com.mercadolibre.android.andesui.textfield.content
+
+import android.content.Context
+import android.graphics.drawable.BitmapDrawable
+import android.view.View
+import android.widget.TextView
+import com.facebook.drawee.view.SimpleDraweeView
+import com.mercadolibre.android.andesui.R
+import com.mercadolibre.android.andesui.button.AndesButton
+import com.mercadolibre.android.andesui.button.hierarchy.AndesButtonHierarchy
+import com.mercadolibre.android.andesui.button.size.AndesButtonSize
+import com.mercadolibre.android.andesui.color.toAndesColor
+import com.mercadolibre.android.andesui.icons.OfflineIconProvider
+import com.mercadolibre.android.andesui.utils.buildColoredBitmapDrawable
+
+/**
+ * Defines all style related properties that an [AndesTexfield] needs to be drawn properly.
+ * Those properties change depending on the style of the message.
+ *
+ */
+internal sealed class AndesTextfieldContentInterface {
+    abstract fun component(context: Context): View
+    abstract fun leftMargin(context: Context) : Int
+    abstract fun rightMargin(context: Context) : Int
+}
+
+internal object AndesSuffixTextfieldContent : AndesTextfieldContentInterface() {
+    override fun leftMargin(context: Context): Int = context.resources.getDimension(R.dimen.andes_textfield_suffix_left_margin).toInt()
+
+    override fun rightMargin(context: Context): Int = context.resources.getDimension(R.dimen.andes_textfield_suffix_right_margin).toInt()
+
+    override fun component(context: Context): TextView {
+        return TextView(context)
+    }
+}
+
+
+internal object AndesPrefixTextfieldContent : AndesTextfieldContentInterface() {
+    override fun leftMargin(context: Context): Int = context.resources.getDimension(R.dimen.andes_textfield_prefix_left_margin).toInt()
+
+    override fun rightMargin(context: Context): Int = context.resources.getDimension(R.dimen.andes_textfield_prefix_right_margin).toInt()
+
+    override fun component(context: Context): TextView {
+        return TextView(context)
+    }
+}
+
+internal object AndesIconTextfieldContent : AndesTextfieldContentInterface() {
+    override fun leftMargin(context: Context): Int = context.resources.getDimension(R.dimen.andes_textfield_icon_left_margin).toInt()
+
+    override fun rightMargin(context: Context): Int = context.resources.getDimension(R.dimen.andes_textfield_icon_right_margin).toInt()
+
+    override fun component(context: Context): SimpleDraweeView {
+        return SimpleDraweeView(context)
+    }
+}
+
+internal object AndesTooltipTextfieldContent : AndesTextfieldContentInterface() {
+    override fun leftMargin(context: Context): Int = context.resources.getDimension(R.dimen.andes_textfield_tooltip_left_margin).toInt()
+
+    override fun rightMargin(context: Context): Int = context.resources.getDimension(R.dimen.andes_textfield_tooltip_right_margin).toInt()
+
+    override fun component(context: Context): View {
+        TODO("not implemented") //To change body of created functions use File | Settings | File Templates.
+    }
+}
+
+internal object AndesValidatedTextfieldContent : AndesTextfieldContentInterface() {
+    override fun leftMargin(context: Context): Int = context.resources.getDimension(R.dimen.andes_textfield_validated_left_margin).toInt()
+
+    override fun rightMargin(context: Context): Int = context.resources.getDimension(R.dimen.andes_textfield_validated_right_margin).toInt()
+
+    override fun component(context: Context): SimpleDraweeView {
+        val validated =  SimpleDraweeView(context)
+        validated.setImageDrawable(buildColoredBitmapDrawable(
+                OfflineIconProvider(context).loadIcon("andes_ui_feedback_success_24") as BitmapDrawable,
+                context,
+                R.color.andes_green_500.toAndesColor())
+        )
+        return validated
+    }
+}
+
+internal object AndesClearTextfieldContent : AndesTextfieldContentInterface() {
+    override fun leftMargin(context: Context): Int = context.resources.getDimension(R.dimen.andes_textfield_clear_left_margin).toInt()
+
+    override fun rightMargin(context: Context): Int = context.resources.getDimension(R.dimen.andes_textfield_clear_right_margin).toInt()
+
+    override fun component(context: Context): SimpleDraweeView {
+        val validated =  SimpleDraweeView(context)
+        validated.setImageDrawable(buildColoredBitmapDrawable(
+                OfflineIconProvider(context).loadIcon("andes_ui_close_24") as BitmapDrawable,
+                context,
+                R.color.andes_gray_450.toAndesColor())
+        )
+        return validated    }
+}
+
+internal object AndesActionTextfieldContent : AndesTextfieldContentInterface() {
+    override fun leftMargin(context: Context): Int = context.resources.getDimension(R.dimen.andes_textfield_action_left_margin).toInt()
+
+    override fun rightMargin(context: Context): Int = context.resources.getDimension(R.dimen.andes_textfield_action_right_margin).toInt()
+
+    override fun component(context: Context): AndesButton {
+        return AndesButton(context, AndesButtonSize.MEDIUM, AndesButtonHierarchy.TRANSPARENT)
+    }
+}
+
+internal object AndesIndeterminateTextfieldContent : AndesTextfieldContentInterface() {
+    override fun leftMargin(context: Context): Int = context.resources.getDimension(R.dimen.andes_textfield_indeterminate_left_margin).toInt()
+
+    override fun rightMargin(context: Context): Int = context.resources.getDimension(R.dimen.andes_textfield_indeterminate_right_margin).toInt()
+
+    override fun component(context: Context): View {
+        TODO("not implemented") //To change body of created functions use File | Settings | File Templates.
+    }
+}
+
+internal object AndesCheckboxTextfieldContent : AndesTextfieldContentInterface() {
+    override fun leftMargin(context: Context): Int = 0
+
+    override fun rightMargin(context: Context): Int = 0
+
+    override fun component(context: Context): View {
+        TODO("not implemented") //To change body of created functions use File | Settings | File Templates.
+    }
+}
+
+

--- a/components/src/main/java/com/mercadolibre/android/andesui/textfield/content/AndesTextfieldContentInterface.kt
+++ b/components/src/main/java/com/mercadolibre/android/andesui/textfield/content/AndesTextfieldContentInterface.kt
@@ -10,6 +10,7 @@ import com.mercadolibre.android.andesui.button.AndesButton
 import com.mercadolibre.android.andesui.button.hierarchy.AndesButtonHierarchy
 import com.mercadolibre.android.andesui.button.size.AndesButtonSize
 import com.mercadolibre.android.andesui.color.toAndesColor
+import com.mercadolibre.android.andesui.color.toColor
 import com.mercadolibre.android.andesui.icons.OfflineIconProvider
 import com.mercadolibre.android.andesui.utils.buildColoredBitmapDrawable
 
@@ -30,7 +31,10 @@ internal object AndesSuffixTextfieldContent : AndesTextfieldContentInterface() {
     override fun rightMargin(context: Context): Int = context.resources.getDimension(R.dimen.andes_textfield_suffix_right_margin).toInt()
 
     override fun component(context: Context): TextView {
-        return TextView(context)
+        val suffix  = TextView(context)
+        suffix.setTextColor(R.color.andes_gray_450.toColor(context))
+        suffix.text = "Suffix"
+        return suffix
     }
 }
 
@@ -41,7 +45,10 @@ internal object AndesPrefixTextfieldContent : AndesTextfieldContentInterface() {
     override fun rightMargin(context: Context): Int = context.resources.getDimension(R.dimen.andes_textfield_prefix_right_margin).toInt()
 
     override fun component(context: Context): TextView {
-        return TextView(context)
+        val prefix  = TextView(context)
+        prefix.setTextColor(R.color.andes_gray_450.toColor(context))
+        prefix.text = "Prefix"
+        return prefix
     }
 }
 
@@ -51,7 +58,12 @@ internal object AndesIconTextfieldContent : AndesTextfieldContentInterface() {
     override fun rightMargin(context: Context): Int = context.resources.getDimension(R.dimen.andes_textfield_icon_right_margin).toInt()
 
     override fun component(context: Context): SimpleDraweeView {
-        return SimpleDraweeView(context)
+        val icon = SimpleDraweeView(context)
+        icon.setImageDrawable(buildColoredBitmapDrawable(
+                OfflineIconProvider(context).loadIcon("andes_ui_placeholder_imagen_24") as BitmapDrawable,
+                context,
+                R.color.andes_gray_800.toAndesColor()))
+        return icon
     }
 }
 

--- a/components/src/main/java/com/mercadolibre/android/andesui/textfield/factory/AndesTexfieldAttrsParser.kt
+++ b/components/src/main/java/com/mercadolibre/android/andesui/textfield/factory/AndesTexfieldAttrsParser.kt
@@ -4,6 +4,8 @@ package com.mercadolibre.android.andesui.textfield.factory
 import android.content.Context
 import android.util.AttributeSet
 import com.mercadolibre.android.andesui.R
+import com.mercadolibre.android.andesui.textfield.content.AndesTextfieldLeftContent
+import com.mercadolibre.android.andesui.textfield.content.AndesTextfieldRightContent
 import com.mercadolibre.android.andesui.textfield.state.AndesTextfieldState
 
 /**
@@ -13,12 +15,25 @@ internal data class AndesTextfieldAttrs(val label: String?,
                                         val helper: String?,
                                         val placeholder: String?,
                                         val counter: AndesTextfieldCounter?,
-                                        val state: AndesTextfieldState)
+                                        val state: AndesTextfieldState,
+                                        val leftContent: AndesTextfieldLeftContent?,
+                                        val rightContent: AndesTextfieldRightContent?)
 
 /**
  * This object parse the attribute set and return an instance of AndesMessageAttrs to be used by AndesMessage
  */
 internal object AndesTextfieldAttrsParser {
+
+    private const val ANDES_TEXTFIELD_CONTENT_PREFIX = "10"
+    private const val ANDES_TEXTFIELD_CONTENT_SUFFIX = "11"
+    private const val ANDES_TEXTFIELD_CONTENT_ICON = "12"
+    private const val ANDES_TEXTFIELD_CONTENT_TOOLTIP = "13"
+    private const val ANDES_TEXTFIELD_CONTENT_VALIDATED = "14"
+    private const val ANDES_TEXTFIELD_CONTENT_CLEAR = "15"
+    private const val ANDES_TEXTFIELD_CONTENT_ACTION = "16"
+    private const val ANDES_TEXTFIELD_CONTENT_INDETERMINATE = "17"
+    private const val ANDES_TEXTFIELD_CONTENT_CHECKBOX = "18"
+
 
     private const val ANDES_TEXTFIELD_STATE_ENABLED = "20"
     private const val ANDES_TEXTFIELD_STATE_ERROR = "21"
@@ -35,6 +50,24 @@ internal object AndesTextfieldAttrsParser {
             else -> AndesTextfieldState.ENABLED
         }
 
+        val leftContent = when (typedArray.getString(R.styleable.AndesTextfield_andesTextfieldLeftContent)) {
+            ANDES_TEXTFIELD_CONTENT_PREFIX -> AndesTextfieldLeftContent.PREFIX
+            ANDES_TEXTFIELD_CONTENT_ICON -> AndesTextfieldLeftContent.ICON
+            else -> null
+        }
+
+        val rightContent = when (typedArray.getString(R.styleable.AndesTextfield_andesTextfieldRightContent)) {
+            ANDES_TEXTFIELD_CONTENT_SUFFIX -> AndesTextfieldRightContent.SUFFIX
+            ANDES_TEXTFIELD_CONTENT_ICON -> AndesTextfieldRightContent.ICON
+            ANDES_TEXTFIELD_CONTENT_TOOLTIP -> AndesTextfieldRightContent.TOOLTIP
+            ANDES_TEXTFIELD_CONTENT_VALIDATED -> AndesTextfieldRightContent.VALIDATED
+            ANDES_TEXTFIELD_CONTENT_CLEAR -> AndesTextfieldRightContent.CLEAR
+            ANDES_TEXTFIELD_CONTENT_ACTION -> AndesTextfieldRightContent.ACTION
+            ANDES_TEXTFIELD_CONTENT_INDETERMINATE -> AndesTextfieldRightContent.INDETERMINATE
+            ANDES_TEXTFIELD_CONTENT_CHECKBOX -> AndesTextfieldRightContent.CHECKBOX
+            else -> null
+        }
+
 
         val counterMinValue = typedArray.getInt(R.styleable.AndesTextfield_andesTexfieldCounterMinValue, 0)
 
@@ -45,7 +78,9 @@ internal object AndesTextfieldAttrsParser {
                 helper = typedArray.getString(R.styleable.AndesTextfield_andesTextfieldHelper),
                 placeholder = typedArray.getString(R.styleable.AndesTextfield_andesTextfieldHint),
                 counter = AndesTextfieldCounter(counterMinValue, counterMaxValue),
-                state = state
+                state = state,
+                leftContent = leftContent,
+                rightContent = rightContent
         ).also { typedArray.recycle() }
     }
 }

--- a/components/src/main/java/com/mercadolibre/android/andesui/textfield/factory/AndesTextfieldConfigurationFactory.kt
+++ b/components/src/main/java/com/mercadolibre/android/andesui/textfield/factory/AndesTextfieldConfigurationFactory.kt
@@ -5,8 +5,8 @@ import android.graphics.Typeface
 import android.graphics.drawable.Drawable
 import android.view.View
 import com.mercadolibre.android.andesui.R
-import com.mercadolibre.android.andesui.textfield.content.AndesTextfieldContentInterface
 import com.mercadolibre.android.andesui.color.AndesColor
+import com.mercadolibre.android.andesui.textfield.content.AndesTextfieldContentInterface
 import com.mercadolibre.android.andesui.textfield.state.AndesTextfieldStateInterface
 import com.mercadolibre.android.andesui.typeface.getFontOrDefault
 
@@ -43,19 +43,19 @@ internal object AndesTextfieldConfigurationFactory {
 
             AndesTextfieldConfiguration(
                     background = resolveBackground(context, state.state),
-                    helperColor = resolveHelperTextColor(state),
+                    helperColor = resolveHelperTextColor(state.state),
                     helperText = helper,
                     helperSize = resolveHelperSize(context),
-                    helperTypeface = resolveHelperTypeface(state, context),
-                    labelColor = resolveLabelTextColor(state),
+                    helperTypeface = resolveHelperTypeface(state.state, context),
+                    labelColor = resolveLabelTextColor(state.state),
                     labelText = label,
                     labelSize = resolveLabelSize(context),
-                    counterColor = resolveCounterTextColor(state),
+                    counterColor = resolveCounterTextColor(state.state),
                     counterSize = resolveCounterSize(context),
                     counterMinLength = counter!!.minLength,
                     counterMaxLength = counter!!.maxLength,
                     placeHolderText = placeholder,
-                    placeHolderColor = resolvePlaceHolderColor(state, context),
+                    placeHolderColor = resolvePlaceHolderColor(state.state, context),
                     placeHolderSize = resolvePlaceHolderSize(context),
                     typeface = resolveTypeface(context),
                     icon = resolveIcon(context, state.state),

--- a/components/src/main/java/com/mercadolibre/android/andesui/textfield/factory/AndesTextfieldConfigurationFactory.kt
+++ b/components/src/main/java/com/mercadolibre/android/andesui/textfield/factory/AndesTextfieldConfigurationFactory.kt
@@ -3,7 +3,9 @@ package com.mercadolibre.android.andesui.textfield.factory
 import android.content.Context
 import android.graphics.Typeface
 import android.graphics.drawable.Drawable
+import android.view.View
 import com.mercadolibre.android.andesui.R
+import com.mercadolibre.android.andesui.textfield.content.AndesTextfieldContentInterface
 import com.mercadolibre.android.andesui.textfield.state.AndesTextfieldStateInterface
 import com.mercadolibre.android.andesui.typeface.getFontOrDefault
 
@@ -13,24 +15,33 @@ internal data class AndesTextfieldConfiguration(
         //val labelTextColor : ColorStateList,
         //val counterTextColor : ColorStateList,
         val typeface: Typeface,
-        val icon: Drawable?
-
+        val icon: Drawable?,
+        val leftComponent : View?,
+        val rightComponent : View?,
+        val leftComponentLeftMargin: Int?,
+        val leftComponentRightMargin: Int?,
+        val rightComponentLeftMargin : Int?,
+        val rightComponentRightMargin: Int?
         )
 
 internal object AndesTextfieldConfigurationFactory {
 
     fun create(context: Context, andesTextfieldAttrs: AndesTextfieldAttrs): AndesTextfieldConfiguration {
-        val state = andesTextfieldAttrs.state.state
-
         return with(andesTextfieldAttrs) {
 
             AndesTextfieldConfiguration(
-                    background = resolveBackground(context, state),
+                    background = resolveBackground(context, state.state),
                     //helperTextColor = resolveHelperTextColor(context),
                     //labelTextColor = resolveLabelTextColor(context),
                     //counterTextColor = resolveCounterTextColor(context),
                     typeface = resolveTypeface(context),
-                    icon = resolveIcon(context, state)
+                    icon = resolveIcon(context, state.state),
+                    leftComponent = resolveLeftComponent(context, leftContent?.leftContent),
+                    rightComponent = resolveRightComponent(context,rightContent?.rightContent),
+                    leftComponentLeftMargin = resolveLeftComponentLeftMargin(context, leftContent?.leftContent),
+                    leftComponentRightMargin = resolveLeftComponentRightMargin(context, leftContent?.leftContent),
+                    rightComponentLeftMargin = resolveRightComponentLeftMargin(context, rightContent?.rightContent),
+                    rightComponentRightMargin = resolveRightComponentRightMargin(context, rightContent?.rightContent)
 
             )
         }
@@ -42,7 +53,11 @@ internal object AndesTextfieldConfigurationFactory {
     //private fun resolveCounterTextColor(context: Context) : ColorStateList
     private fun resolveTypeface(context: Context) =  context.getFontOrDefault(R.font.andes_font_regular)
     private fun resolveIcon(context: Context, state: AndesTextfieldStateInterface) : Drawable? = state.icon(context)
-
-
+    private fun resolveLeftComponent(context: Context, leftContent: AndesTextfieldContentInterface?) : View? = leftContent?.component(context)
+    private fun resolveRightComponent(context: Context, rightContent: AndesTextfieldContentInterface?) : View? = rightContent?.component(context)
+    private fun resolveLeftComponentLeftMargin(context: Context, leftContent: AndesTextfieldContentInterface?) : Int? = leftContent?.leftMargin(context)
+    private fun resolveLeftComponentRightMargin(context: Context, leftContent: AndesTextfieldContentInterface?) : Int? = leftContent?.rightMargin(context)
+    private fun resolveRightComponentLeftMargin(context: Context, rightContent: AndesTextfieldContentInterface?) : Int? = rightContent?.leftMargin(context)
+    private fun resolveRightComponentRightMargin(context: Context, rightContent: AndesTextfieldContentInterface?) : Int? = rightContent?.rightMargin(context)
 }
 

--- a/components/src/main/java/com/mercadolibre/android/andesui/textfield/state/AndesTextfieldState.kt
+++ b/components/src/main/java/com/mercadolibre/android/andesui/textfield/state/AndesTextfieldState.kt
@@ -6,7 +6,7 @@ package com.mercadolibre.android.andesui.textfield.state
  *
  * You ask me with, let's say 'ENABLED', and then I'll give you a proper implementation of that state.
  *
- * @property state Possible hierarchies that an [AndesTextfield] may take.
+ * @property state Possible states that an [AndesTextfield] may take.
  */
 enum class AndesTextfieldState {
         ENABLED,

--- a/components/src/main/res/textfield/layout/andes_layout_texfield.xml
+++ b/components/src/main/res/textfield/layout/andes_layout_texfield.xml
@@ -25,20 +25,40 @@
         android:addStatesFromChildren="true"
         >
 
+        <FrameLayout
+            android:id="@+id/andes_textfield_left_component"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_marginStart="12dp"
+            app:layout_constraintBottom_toBottomOf="@id/andes_textfield_text_container"
+            app:layout_constraintEnd_toStartOf="@id/andes_textfield_edittext"
+            app:layout_constraintHorizontal_bias="0.0"
+            app:layout_constraintStart_toStartOf="@id/andes_textfield_text_container"
+            app:layout_constraintTop_toTopOf="@id/andes_textfield_text_container" />
+
         <EditText
             android:id="@+id/andes_textfield_edittext"
-            android:layout_width="match_parent"
-            android:layout_height="match_parent"
-            android:inputType="text"
-            app:layout_constraintEnd_toEndOf="parent"
-            app:layout_constraintHorizontal_bias="0.0"
-            app:layout_constraintStart_toStartOf="parent"
-            app:layout_constraintTop_toTopOf="parent"
-            android:textSize="@dimen/andes_textfield_edittext_textSize"
-            android:paddingLeft="@dimen/andes_textfield_edittext_paddingLeft"
-            android:paddingRight="@dimen/andes_textfield_edittext_paddingRight"
+            android:layout_width="0dp"
+            android:layout_height="0dp"
             android:background="@drawable/andes_border"
-            android:textCursorDrawable="@drawable/andes_color_cursor" />
+            android:inputType="text"
+            android:textCursorDrawable="@drawable/andes_color_cursor"
+            android:textSize="@dimen/andes_textfield_edittext_textSize"
+            app:layout_constraintBottom_toBottomOf="parent"
+            app:layout_constraintEnd_toStartOf="@+id/andes_textfield_right_component"
+            app:layout_constraintStart_toEndOf="@+id/andes_textfield_left_component"
+            app:layout_constraintTop_toTopOf="parent"
+            app:layout_goneMarginEnd="12dp"
+            app:layout_goneMarginStart="12dp" />
+
+        <FrameLayout
+            android:id="@+id/andes_textfield_right_component"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            app:layout_constraintBottom_toBottomOf="@id/andes_textfield_text_container"
+            app:layout_constraintStart_toEndOf="@id/andes_textfield_edittext"
+            app:layout_constraintEnd_toEndOf="@id/andes_textfield_text_container"
+            app:layout_constraintTop_toTopOf="@id/andes_textfield_text_container" />
 
     </android.support.constraint.ConstraintLayout>
 

--- a/components/src/main/res/textfield/values/attrs.xml
+++ b/components/src/main/res/textfield/values/attrs.xml
@@ -12,11 +12,28 @@
 
         <attr name="andesTexfieldCounterMaxValue" format="integer" />
 
-
         <attr name="andesTextfieldState">
             <enum name="enabled" value="20" />
             <enum name="error" value="21" />
             <enum name="disabled" value="22" />
+        </attr>
+
+        <attr name="andesTextfieldLeftContent">
+            <enum name="prefix" value="10" />
+            <enum name="icon" value="12" />
+        </attr>
+
+
+        <attr name="andesTextfieldRightContent">
+            <enum name="prefix" value="10" />
+            <enum name="suffix" value="11" />
+            <enum name="icon" value="12" />
+            <enum name="tooltip" value="13" />
+            <enum name="validated" value="14" />
+            <enum name="clear" value="15" />
+            <enum name="action" value="16" />
+            <enum name="indeterminate" value="17" />
+            <enum name="checkbox" value="18" />
         </attr>
 
 

--- a/components/src/main/res/textfield/values/dimens.xml
+++ b/components/src/main/res/textfield/values/dimens.xml
@@ -6,4 +6,5 @@
     <dimen name="andes_textfield_dash">1dp</dimen>
     <dimen name="andes_textfield_icon_diameter">12dp</dimen>
 
+
 </resources>

--- a/components/src/main/res/textfield/values/dimens_textfield.xml
+++ b/components/src/main/res/textfield/values/dimens_textfield.xml
@@ -8,7 +8,7 @@
 
     <dimen name="andes_textfield_edittext_paddingLeft">12dp</dimen>
     <dimen name="andes_textfield_edittext_paddingRight">12dp</dimen>
-    <dimen name="andes_textfield_edittext_textSize">16dp</dimen>
+    <dimen name="andes_textfield_edittext_textSize">16sp</dimen>
 
     <dimen name="andes_textfield_helper_paddingLeft">6dp</dimen>
     <dimen name="andes_textfield_helper_textSize">13dp</dimen>
@@ -16,4 +16,28 @@
 
     <dimen name="andes_textfield_counter_textSize">13dp</dimen>
     <dimen name="andes_textfield_counter_marginTop">8dp</dimen>
+
+    <dimen name="andes_textfield_prefix_left_margin">12dp</dimen>
+    <dimen name="andes_textfield_prefix_right_margin">8dp</dimen>
+
+    <dimen name="andes_textfield_suffix_left_margin">8dp</dimen>
+    <dimen name="andes_textfield_suffix_right_margin">12dp</dimen>
+
+    <dimen name="andes_textfield_icon_left_margin">12dp</dimen>
+    <dimen name="andes_textfield_icon_right_margin">12dp</dimen>
+
+    <dimen name="andes_textfield_tooltip_left_margin">12dp</dimen>
+    <dimen name="andes_textfield_tooltip_right_margin">12dp</dimen>
+
+    <dimen name="andes_textfield_validated_left_margin">12dp</dimen>
+    <dimen name="andes_textfield_validated_right_margin">12dp</dimen>
+
+    <dimen name="andes_textfield_clear_left_margin">8dp</dimen>
+    <dimen name="andes_textfield_clear_right_margin">8dp</dimen>
+
+    <dimen name="andes_textfield_action_left_margin">8dp</dimen>
+    <dimen name="andes_textfield_action_right_margin">8dp</dimen>
+
+    <dimen name="andes_textfield_indeterminate_left_margin">12dp</dimen>
+    <dimen name="andes_textfield_indeterminate_right_margin">12dp</dimen>
 </resources>

--- a/components/src/main/res/textfield/values/strings.xml
+++ b/components/src/main/res/textfield/values/strings.xml
@@ -4,4 +4,6 @@
     <string name="andes_textfield_helper_text">Helper text</string>
     <string name="andes_textfield_counter_text">%1$d/%2$d</string>
     <string name="andes_textfield_hint_text">Input text</string>
+    <string name="andes_suffix_hint">Suffix</string>
+    <string name="andes_prefix_hint">Prefix</string>
 </resources>

--- a/demoapp/src/main/java/com/mercadolibre/android/andesui/demoapp/feature/TextfieldShowcaseActivity.kt
+++ b/demoapp/src/main/java/com/mercadolibre/android/andesui/demoapp/feature/TextfieldShowcaseActivity.kt
@@ -11,6 +11,7 @@ import android.view.ViewGroup
 import android.widget.ScrollView
 import com.mercadolibre.android.andesui.demoapp.PageIndicator
 import com.mercadolibre.android.andesui.demoapp.R
+import com.mercadolibre.android.andesui.textfield.AndesTextfield
 
 class TextfieldShowcaseActivity : AppCompatActivity() {
     override fun onCreate(savedInstanceState: Bundle?) {
@@ -58,6 +59,18 @@ class AndesShowcasePagerAdapter(private val context: Context) : PagerAdapter() {
 
     private fun addTextfield(inflater: LayoutInflater): View {
         val layoutTextfield = inflater.inflate(R.layout.andesui_textfield_showcase, null, false) as ScrollView
+
+        val textfield = layoutTextfield.findViewById<AndesTextfield>(R.id.textfield_enabled)
+
+
+        /*
+        textfield.setupAction("Action", View.OnClickListener {
+            Toast.makeText(context, "Primary onClick", Toast.LENGTH_SHORT).show()
+        })
+
+        textfield.setupClear()*/
+
+        textfield.setupPrefix("+546666")
 
         return layoutTextfield
     }

--- a/demoapp/src/main/res/layout/andesui_textfield_showcase.xml
+++ b/demoapp/src/main/res/layout/andesui_textfield_showcase.xml
@@ -33,8 +33,6 @@
             android:layout_height="wrap_content"
             app:andesTextfieldState="error"
             android:layout_marginBottom="@dimen/button_margin_vertical"
-
-
             />
 
         <com.mercadolibre.android.andesui.textfield.AndesTextfield

--- a/demoapp/src/main/res/layout/andesui_textfield_showcase.xml
+++ b/demoapp/src/main/res/layout/andesui_textfield_showcase.xml
@@ -24,7 +24,7 @@
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
             android:layout_marginBottom="@dimen/button_margin_vertical"
-            app:andesTextfieldLeftContent="prefix"
+            app:andesTextfieldLeftContent="icon"
             app:andesTextfieldRightContent="clear"
             />
 

--- a/demoapp/src/main/res/layout/andesui_textfield_showcase.xml
+++ b/demoapp/src/main/res/layout/andesui_textfield_showcase.xml
@@ -20,9 +20,12 @@
             android:textSize="24sp" />
 
         <com.mercadolibre.android.andesui.textfield.AndesTextfield
+            android:id="@+id/textfield_enabled"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
             android:layout_marginBottom="@dimen/button_margin_vertical"
+            app:andesTextfieldLeftContent="prefix"
+            app:andesTextfieldRightContent="clear"
             />
 
         <com.mercadolibre.android.andesui.textfield.AndesTextfield
@@ -31,7 +34,9 @@
             app:andesTextfieldState="error"
             android:layout_marginBottom="@dimen/button_margin_vertical"
 
+
             />
+
         <com.mercadolibre.android.andesui.textfield.AndesTextfield
             android:layout_width="match_parent"
             android:layout_height="wrap_content"


### PR DESCRIPTION
### Thanks for starting a pull request on Andes UI!

## Motivation
Adding right and left texfield contents.

## Affected component
Textfield

## Frontify component link
The UX team behind Andes keeps all the Andes Components inside the Frontify site. Each component has its own section. Let us know the section of the component you want to modify.

## Screenshots
![Screenshot_1584565346](https://user-images.githubusercontent.com/51792499/77007369-dcb79c00-6942-11ea-88bb-b2b234dd4caf.png)

![Screenshot_1584565561](https://user-images.githubusercontent.com/51792499/77007575-33bd7100-6943-11ea-8dcf-da7b188ffe71.png)

![Screenshot_1584565664](https://user-images.githubusercontent.com/51792499/77007679-62d3e280-6943-11ea-9add-d9bbfc64fe5c.png)


## Checks
Are you sure you followed all those steps? In such case, let's say with me "I solemnly declare that ...":
- [X] I have coded an example inside the Demo App,
- [ ] I have added proper tests,
- [X] I have modified the [Changelog](https://github.com/mercadolibre/fury_andesui-android/blob/develop/CHANGELOG.md) file,
- [ ] I have updated GitHub wiki,
- [X] I have the explicit approval of one or more members of the UX Team,
- [X] I have updated the version in gradle.properties file.

## Change type
This is easy, let us know what this code is about:
- [ ] This code adds a new component
- [X] This code includes improvements to an existent component
- [ ] This code improves or modifies ONLY the Demo App.

## Check common errors
Whether you are an Android or iOS developer and if you're still there then we'll give you a present:
https://proandroiddev.com/how-to-maximize-androids-ui-reusability-5-common-mistakes-cb2571216a9f
