### PR TITLE
Migrated to Gradle 5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# v2.2.0
+## Updated
+- Migrated build system to Gradle v5.6.4
+
 # v2.1.0
 ## Added
 - Initial Texfield component

--- a/demoapp/build.gradle
+++ b/demoapp/build.gradle
@@ -85,15 +85,12 @@ dependencies {
 }
 
 /**
- * Based on https://discuss.gradle.org/t/how-to-copy-and-rename-a-single-file/5956
+ * Based on https://stackoverflow.com/a/44218054/2823516
  */
-task copyChangelog(type: Copy) {
-    logger.info("Copying CHANGELOG.md file to the Andes app...")
-    from '../CHANGELOG.md'
+copy {
+    from file ('../CHANGELOG.md')
     into 'src/main/res/raw'
     rename { String fileName ->
         fileName.replace("CHANGELOG.md", "andesui_demoapp_changelog.md")
     }
 }
-
-tasks.copyChangelog.execute()

--- a/demoapp/src/main/res/raw/andesui_demoapp_changelog.md
+++ b/demoapp/src/main/res/raw/andesui_demoapp_changelog.md
@@ -1,3 +1,7 @@
+# v2.2.0
+## Updated
+- Migrated build system to Gradle v5.6.4
+
 # v2.1.0
 ## Added
 - Initial Texfield component

--- a/gradle.properties
+++ b/gradle.properties
@@ -34,7 +34,7 @@ libraryGroupId=com.mercadolibre.android.andesui
 # IMPORTANT: We're using http://semver.org/ for all Android projects, please remember to follow this convention.
 # IMPORTANT: The version will be THE SAME for all modules.
 # For libraryVersion do NOT add a qualifier to this version like LOCAL/EXPERIMENTAL (it'll be added automatically!)
-libraryVersion=2.1.0
+libraryVersion=2.2.0
 
 ##################################################################################
 # Project setup

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-4.10.3-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-5.6.4-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists


### PR DESCRIPTION
## Motivation
We're using Gradle 5 at Meli, so I thought we also should use Gradle 5 here, don't you think?

## Description
Same: Gradle 4 is old and boring. Gradle 5 is newer and we're using it in other projects so let's be in sync!

## Affected component
Entire module

## Frontify component link
N/A

## Screenshots
Really?

## Checks
Are you sure you followed all those steps? In such case, let's say with me "I solemnly declare that ...":
- [ ] I have coded an example inside the Demo App,
- [ ] I have added proper tests,
- [x] I have modified the [Changelog](https://github.com/mercadolibre/fury_andesui-android/blob/develop/CHANGELOG.md) file,
- [ ] I have updated GitHub wiki,
- [ ] I have the explicit approval of one or more members of the UX Team,
- [x] I have updated the version in gradle.properties file.

## Change type
This is easy, let us know what this code is about:
- [ ] This code adds a new component
- [x] This code includes improvements to an existent component
- [x] This code improves or modifies ONLY the Demo App.
