### PR TITLE
InputType added to Andes Textfield

### DIFF
--- a/components/src/main/java/com/mercadolibre/android/andesui/textfield/AndesTextfield.kt
+++ b/components/src/main/java/com/mercadolibre/android/andesui/textfield/AndesTextfield.kt
@@ -5,6 +5,7 @@ import android.graphics.drawable.BitmapDrawable
 import android.support.constraint.ConstraintLayout
 import android.text.Editable
 import android.text.InputFilter
+import android.text.InputType
 import android.text.TextWatcher
 import android.util.AttributeSet
 import android.util.TypedValue
@@ -23,6 +24,7 @@ import com.mercadolibre.android.andesui.textfield.content.AndesTextfieldRightCon
 import com.mercadolibre.android.andesui.textfield.factory.*
 import com.mercadolibre.android.andesui.textfield.state.AndesTextfieldState
 import com.mercadolibre.android.andesui.textfield.state.AndesTextfieldState.*
+import com.mercadolibre.android.andesui.textfield.type.AndesTextfieldType
 import com.mercadolibre.android.andesui.utils.buildColoredBitmapDrawable
 
 
@@ -92,6 +94,13 @@ class AndesTextfield : ConstraintLayout {
             setupRightComponent(createConfig())
         }
 
+    var textType: AndesTextfieldType
+        get() = andesTextfieldAttrs.textType
+        set(value) {
+            andesTextfieldAttrs = andesTextfieldAttrs.copy(textType = value)
+            setupTextType()
+        }
+
     private lateinit var andesTextfieldAttrs: AndesTextfieldAttrs
     private lateinit var textfieldContainer: ConstraintLayout
     private lateinit var textContainer: ConstraintLayout
@@ -105,7 +114,7 @@ class AndesTextfield : ConstraintLayout {
 
     @Suppress("unused")
     constructor(context: Context) : super(context) {
-        initAttrs(LABEL_DEFAULT, HELPER_DEFAULT, PLACEHOLDER_DEFAULT, COUNTER_DEFAULT, STATE_DEFAULT, LEFT_COMPONENT_DEFAULT, RIGHT_COMPONENT_DEFAULT)
+        initAttrs(LABEL_DEFAULT, HELPER_DEFAULT, PLACEHOLDER_DEFAULT, COUNTER_DEFAULT, STATE_DEFAULT, LEFT_COMPONENT_DEFAULT, RIGHT_COMPONENT_DEFAULT, TEXTFIELD_TEXT_TYPE)
     }
 
     constructor(context: Context,
@@ -115,9 +124,10 @@ class AndesTextfield : ConstraintLayout {
                 counter: AndesTextfieldCounter? = COUNTER_DEFAULT,
                 state: AndesTextfieldState = STATE_DEFAULT,
                 leftContent: AndesTextfieldLeftContent? = LEFT_COMPONENT_DEFAULT,
-                rightContent: AndesTextfieldRightContent? = RIGHT_COMPONENT_DEFAULT)
+                rightContent: AndesTextfieldRightContent? = RIGHT_COMPONENT_DEFAULT,
+                textType: AndesTextfieldType = TEXTFIELD_TEXT_TYPE)
             : super(context) {
-        initAttrs(label, helper, placeholder, counter, state, leftContent, rightContent)
+        initAttrs(label, helper, placeholder, counter, state, leftContent, rightContent, textType)
     }
 
     constructor(context: Context, attrs: AttributeSet?) : super(context, attrs) {
@@ -134,8 +144,8 @@ class AndesTextfield : ConstraintLayout {
         setupComponents(config)
     }
 
-    private fun initAttrs(label: String?, helper: String?, placeholder: String?, counter: AndesTextfieldCounter?, state: AndesTextfieldState, leftContent: AndesTextfieldLeftContent?, rightContent: AndesTextfieldRightContent?) {
-        andesTextfieldAttrs = AndesTextfieldAttrs(label, helper, placeholder, counter, state, leftContent, rightContent)
+    private fun initAttrs(label: String?, helper: String?, placeholder: String?, counter: AndesTextfieldCounter?, state: AndesTextfieldState, leftContent: AndesTextfieldLeftContent?, rightContent: AndesTextfieldRightContent?, textType: AndesTextfieldType) {
+        andesTextfieldAttrs = AndesTextfieldAttrs(label, helper, placeholder, counter, state, leftContent, rightContent, textType)
         val config = AndesTextfieldConfigurationFactory.create(context, andesTextfieldAttrs)
         setupComponents(config)
     }
@@ -152,6 +162,7 @@ class AndesTextfield : ConstraintLayout {
         setupLeftComponent(config)
         setupRightComponent(config)
         setupColorComponents(config)
+        setupTextType()
     }
 
     /**
@@ -196,6 +207,15 @@ class AndesTextfield : ConstraintLayout {
             textComponent.isEnabled = isEnabled
             textContainer.isEnabled = isEnabled
             textfieldContainer.isEnabled = isEnabled
+        }
+    }
+
+    private fun setupTextType() {
+        when (textType) {
+            AndesTextfieldType.TEXT -> textComponent.inputType = InputType.TYPE_CLASS_TEXT or InputType.TYPE_TEXT_VARIATION_NORMAL
+            AndesTextfieldType.NUMBER -> textComponent.inputType = InputType.TYPE_CLASS_NUMBER or InputType.TYPE_NUMBER_VARIATION_NORMAL
+            AndesTextfieldType.PASSWORD -> textComponent.inputType = InputType.TYPE_CLASS_TEXT or InputType.TYPE_TEXT_VARIATION_PASSWORD
+            AndesTextfieldType.EMAIL -> textComponent.inputType = InputType.TYPE_CLASS_TEXT or InputType.TYPE_TEXT_VARIATION_EMAIL_ADDRESS
         }
     }
 
@@ -387,7 +407,6 @@ class AndesTextfield : ConstraintLayout {
         private val STATE_DEFAULT = ENABLED
         private val LEFT_COMPONENT_DEFAULT = null
         private val RIGHT_COMPONENT_DEFAULT = null
-
-
+        private val TEXTFIELD_TEXT_TYPE = AndesTextfieldType.TEXT
     }
 }

--- a/components/src/main/java/com/mercadolibre/android/andesui/textfield/AndesTextfield.kt
+++ b/components/src/main/java/com/mercadolibre/android/andesui/textfield/AndesTextfield.kt
@@ -94,7 +94,7 @@ class AndesTextfield : ConstraintLayout {
             setupRightComponent(createConfig())
         }
 
-    var textType: AndesTextfieldType
+    var textType: AndesTextfieldType?
         get() = andesTextfieldAttrs.textType
         set(value) {
             andesTextfieldAttrs = andesTextfieldAttrs.copy(textType = value)

--- a/components/src/main/java/com/mercadolibre/android/andesui/textfield/factory/AndesTexfieldAttrsParser.kt
+++ b/components/src/main/java/com/mercadolibre/android/andesui/textfield/factory/AndesTexfieldAttrsParser.kt
@@ -7,6 +7,7 @@ import com.mercadolibre.android.andesui.R
 import com.mercadolibre.android.andesui.textfield.content.AndesTextfieldLeftContent
 import com.mercadolibre.android.andesui.textfield.content.AndesTextfieldRightContent
 import com.mercadolibre.android.andesui.textfield.state.AndesTextfieldState
+import com.mercadolibre.android.andesui.textfield.type.AndesTextfieldType
 
 /**
  * The data class that contains the public components of the textfield.
@@ -17,7 +18,8 @@ internal data class AndesTextfieldAttrs(val label: String?,
                                         val counter: AndesTextfieldCounter?,
                                         val state: AndesTextfieldState,
                                         val leftContent: AndesTextfieldLeftContent?,
-                                        val rightContent: AndesTextfieldRightContent?)
+                                        val rightContent: AndesTextfieldRightContent?,
+                                        val textType: AndesTextfieldType)
 
 /**
  * This object parse the attribute set and return an instance of AndesMessageAttrs to be used by AndesMessage
@@ -39,6 +41,11 @@ internal object AndesTextfieldAttrsParser {
     private const val ANDES_TEXTFIELD_STATE_ERROR = "21"
     private const val ANDES_TEXTFIELD_STATE_DISABLED = "22"
     private const val ANDES_TEXTFIELD_STATE_READONLY = "23"
+
+    private const val ANDES_TEXTFIELD_TYPE_TEXT = "30"
+    private const val ANDES_TEXTFIELD_TYPE_NUMBERS = "31"
+    private const val ANDES_TEXTFIELD_TYPE_PASSWORD = "32"
+    private const val ANDES_TEXTFIELD_TYPE_EMAIL = "33"
 
 
     fun parse(context: Context, attr: AttributeSet?): AndesTextfieldAttrs {
@@ -70,6 +77,13 @@ internal object AndesTextfieldAttrsParser {
             else -> null
         }
 
+        val textType = when (typedArray.getString(R.styleable.AndesTextfield_andesTextfieldType)) {
+            ANDES_TEXTFIELD_TYPE_TEXT -> AndesTextfieldType.TEXT
+            ANDES_TEXTFIELD_TYPE_NUMBERS -> AndesTextfieldType.NUMBER
+            ANDES_TEXTFIELD_TYPE_PASSWORD -> AndesTextfieldType.PASSWORD
+            ANDES_TEXTFIELD_TYPE_EMAIL -> AndesTextfieldType.EMAIL
+            else -> AndesTextfieldType.TEXT
+        }
 
         val counterMinValue = typedArray.getInt(R.styleable.AndesTextfield_andesTextfieldCounterMinValue, 0)
 
@@ -82,7 +96,8 @@ internal object AndesTextfieldAttrsParser {
                 counter = AndesTextfieldCounter(counterMinValue, counterMaxValue),
                 state = state,
                 leftContent = leftContent,
-                rightContent = rightContent
+                rightContent = rightContent,
+                textType = textType
         ).also { typedArray.recycle() }
     }
 }

--- a/components/src/main/java/com/mercadolibre/android/andesui/textfield/factory/AndesTexfieldAttrsParser.kt
+++ b/components/src/main/java/com/mercadolibre/android/andesui/textfield/factory/AndesTexfieldAttrsParser.kt
@@ -19,7 +19,7 @@ internal data class AndesTextfieldAttrs(val label: String?,
                                         val state: AndesTextfieldState,
                                         val leftContent: AndesTextfieldLeftContent?,
                                         val rightContent: AndesTextfieldRightContent?,
-                                        val textType: AndesTextfieldType)
+                                        val textType: AndesTextfieldType?)
 
 /**
  * This object parse the attribute set and return an instance of AndesMessageAttrs to be used by AndesMessage

--- a/components/src/main/java/com/mercadolibre/android/andesui/textfield/state/AndesTextfieldStateInterface.kt
+++ b/components/src/main/java/com/mercadolibre/android/andesui/textfield/state/AndesTextfieldStateInterface.kt
@@ -32,7 +32,7 @@ internal sealed class AndesTextfieldStateInterface {
 
 internal object AndesEnabledTextfieldState : AndesTextfieldStateInterface() {
     override fun textColor(): AndesColor = R.color.andes_gray_450.toAndesColor()
-    override fun hintColor(): AndesColor = R.color.andes_gray_450.toAndesColor()
+    override fun hintColor(): AndesColor = R.color.andes_gray_800.toAndesColor()
     override fun typeFace(context: Context): Typeface = context.getFontOrDefault(R.font.andes_font_regular)
     override fun helper(helper: String?): String? = helper
     override fun counter(counter: AndesTextfieldCounter): AndesTextfieldCounter? = if (counter.maxLength <= counter.minLength) null else counter
@@ -50,15 +50,15 @@ internal object AndesEnabledTextfieldState : AndesTextfieldStateInterface() {
 
 internal object AndesErrorTextfieldState : AndesTextfieldStateInterface() {
     override fun textColor(): AndesColor = R.color.andes_red_500.toAndesColor()
-    override fun hintColor(): AndesColor = R.color.andes_gray_450.toAndesColor()
+    override fun hintColor(): AndesColor = R.color.andes_gray_800.toAndesColor()
     override fun typeFace(context: Context) = context.getFontOrDefault(R.font.andes_font_semibold)
     override fun helper(helper: String?): String? = helper
     override fun counter(counter: AndesTextfieldCounter): AndesTextfieldCounter? = if (counter.maxLength <= counter.minLength) null else counter
 
     override fun backgroundColor(context: Context): Drawable {
         return StateListDrawable().apply {
-            addState(intArrayOf(android.R.attr.state_focused), createGradientDrawable(context, context.resources.getDimension(R.dimen.andes_textfield_focused_stroke).toInt(), R.color.andes_red_500.toColor(context), R.color.andes_red_50.toColor(context)))
-            addState(intArrayOf(android.R.attr.state_enabled), createGradientDrawable(context, context.resources.getDimension(R.dimen.andes_textfield_simple_stroke).toInt(), R.color.andes_red_500.toColor(context), R.color.andes_red_50.toColor(context)))
+            addState(intArrayOf(android.R.attr.state_focused), createGradientDrawable(context, context.resources.getDimension(R.dimen.andes_textfield_focused_stroke).toInt(), R.color.andes_red_500.toColor(context), R.color.andes_bg_color_white.toColor(context)))
+            addState(intArrayOf(android.R.attr.state_enabled), createGradientDrawable(context, context.resources.getDimension(R.dimen.andes_textfield_simple_stroke).toInt(), R.color.andes_red_500.toColor(context), R.color.andes_bg_color_white.toColor(context)))
         }
     }
 

--- a/components/src/main/java/com/mercadolibre/android/andesui/textfield/type/AndesTextfieldType.kt
+++ b/components/src/main/java/com/mercadolibre/android/andesui/textfield/type/AndesTextfieldType.kt
@@ -1,0 +1,32 @@
+package com.mercadolibre.android.andesui.textfield.type
+
+import com.mercadolibre.android.andesui.textfield.content.AndesIconTextfieldContent
+import com.mercadolibre.android.andesui.textfield.content.AndesPrefixTextfieldContent
+import com.mercadolibre.android.andesui.textfield.content.AndesTextfieldContentInterface
+
+/**
+ * Utility class that does two things: Defines the possible states an [AndesTextfield] can take because it's an enum, as you can see.
+ * But as a bonus it gives you the proper implementation so you don't have to make any mapping.
+ *
+ * You ask me with, let's say 'ENABLED', and then I'll give you a proper implementation of that content.
+ *
+ * @property content Possible contents that an [AndesTextfield] may take.
+ */
+
+enum class AndesTextfieldType {
+    TEXT,
+    NUMBER,
+    PASSWORD,
+    EMAIL;
+
+    internal val textType get() = getAndesTextType()
+
+    private fun getAndesTextType(): String {
+        return when (this) {
+            TEXT -> "text"
+            NUMBER -> "number"
+            PASSWORD -> "textPassword"
+            EMAIL -> "textEmailAddress"
+        }
+    }
+}

--- a/components/src/main/res/textfield/layout/andes_layout_textfield.xml
+++ b/components/src/main/res/textfield/layout/andes_layout_textfield.xml
@@ -40,7 +40,6 @@
             android:layout_width="0dp"
             android:layout_height="0dp"
             android:background="@drawable/andes_border"
-            android:inputType="text"
             android:textCursorDrawable="@drawable/andes_color_cursor"
             android:textSize="@dimen/andes_textfield_edittext_textSize"
             app:layout_constraintBottom_toBottomOf="parent"

--- a/components/src/main/res/textfield/values/attrs.xml
+++ b/components/src/main/res/textfield/values/attrs.xml
@@ -12,6 +12,13 @@
 
         <attr name="andesTextfieldCounterMaxValue" format="integer" />
 
+        <attr name="andesTextfieldType">
+            <enum name="text" value="30" />
+            <enum name="number" value="31" />
+            <enum name="password" value="32" />
+            <enum name="email" value="33" />
+        </attr>
+
         <attr name="andesTextfieldState">
             <enum name="enabled" value="20" />
             <enum name="error" value="21" />

--- a/demoapp/src/main/java/com/mercadolibre/android/andesui/demoapp/feature/TextfieldShowcaseActivity.kt
+++ b/demoapp/src/main/java/com/mercadolibre/android/andesui/demoapp/feature/TextfieldShowcaseActivity.kt
@@ -20,6 +20,7 @@ import com.mercadolibre.android.andesui.textfield.content.AndesTextfieldLeftCont
 import com.mercadolibre.android.andesui.textfield.content.AndesTextfieldRightContent
 import com.mercadolibre.android.andesui.textfield.factory.AndesTextfieldCounter
 import com.mercadolibre.android.andesui.textfield.state.AndesTextfieldState
+import com.mercadolibre.android.andesui.textfield.type.AndesTextfieldType
 
 class TextfieldShowcaseActivity : AppCompatActivity() {
 
@@ -76,6 +77,16 @@ class TextfieldShowcaseActivity : AppCompatActivity() {
             val counterMin = layoutTextfield.findViewById<EditText>(R.id.counter_min)
             val counterMax = layoutTextfield.findViewById<EditText>(R.id.counter_max)
 
+            val textTypeSpinner: Spinner = layoutTextfield.findViewById(R.id.textType_spinner)
+            ArrayAdapter.createFromResource(
+                    context,
+                    R.array.textfield_type_spinner,
+                    android.R.layout.simple_spinner_item
+            ).also { adapter ->
+                adapter.setDropDownViewResource(android.R.layout.simple_spinner_dropdown_item)
+                textTypeSpinner.adapter = adapter
+            }
+
             val stateSpinner: Spinner = layoutTextfield.findViewById(R.id.state_spinner)
             ArrayAdapter.createFromResource(
                     context,
@@ -116,6 +127,13 @@ class TextfieldShowcaseActivity : AppCompatActivity() {
                 val max = counterMax.text.toString().toIntOrNull() ?: 0
                 textfield.counter = AndesTextfieldCounter(min,max)
 
+                when (textTypeSpinner.selectedItem.toString()) {
+                    "Text" -> textfield.textType = AndesTextfieldType.TEXT
+                    "Number" -> textfield.textType = AndesTextfieldType.NUMBER
+                    "Password" -> textfield.textType = AndesTextfieldType.PASSWORD
+                    "Email" -> textfield.textType = AndesTextfieldType.EMAIL
+                }
+
                 when (stateSpinner.selectedItem.toString()) {
                     "Enabled" -> textfield.state = AndesTextfieldState.ENABLED
                     "Disabled" -> textfield.state = AndesTextfieldState.DISABLED
@@ -155,6 +173,7 @@ class TextfieldShowcaseActivity : AppCompatActivity() {
                 textfield.state = AndesTextfieldState.ENABLED
                 textfield.leftContent = null
                 textfield.rightContent = null
+                textfield.textType = AndesTextfieldType.TEXT
             }
 
             return layoutTextfield

--- a/demoapp/src/main/res/layout/andesui_textfield_showcase.xml
+++ b/demoapp/src/main/res/layout/andesui_textfield_showcase.xml
@@ -26,6 +26,7 @@
             android:layout_marginBottom="@dimen/button_margin_vertical"
             app:andesTextfieldLeftContent="icon"
             app:andesTextfieldRightContent="clear"
+            app:andesTextfieldType="text"
             />
 
         <com.mercadolibre.android.andesui.textfield.AndesTextfield
@@ -34,6 +35,7 @@
             android:layout_marginBottom="@dimen/button_margin_vertical"
             app:andesTextfieldLabel="@string/andes_textfield_label_text"
             app:andesTextfieldPlaceholder="@string/andes_textfield_placeholder_text"
+            app:andesTextfieldType="number"
             />
 
         <com.mercadolibre.android.andesui.textfield.AndesTextfield

--- a/demoapp/src/main/res/layout/andesui_textfield_showcase_change.xml
+++ b/demoapp/src/main/res/layout/andesui_textfield_showcase_change.xml
@@ -28,6 +28,18 @@
             />
 
         <TextView
+            android:text="@string/andesui_demoapp_textfield_text_type"
+            android:textColor="@color/andes_gray_800"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content" />
+
+        <Spinner
+            android:id="@+id/textType_spinner"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="10dp" />
+
+        <TextView
             android:text="@string/andesui_demoapp_textfield_state_text"
             android:textColor="@color/andes_gray_800"
             android:layout_width="match_parent"

--- a/demoapp/src/main/res/values/strings.xml
+++ b/demoapp/src/main/res/values/strings.xml
@@ -62,6 +62,7 @@
     <string name="andesui_demoapp_textfield_suffix_text">Suffix:</string>
     <string name="andesui_demoapp_counter_text">Counter:</string>
     <string name="andesui_demoapp_counter_separator">/</string>
+    <string name="andesui_demoapp_textfield_text_type">Text Type</string>
 
 
     <string-array name="state_spinner">
@@ -74,6 +75,13 @@
     <string-array name="hierarchy_spinner">
         <item>Loud</item>
         <item>Quiet</item>
+    </string-array>
+
+    <string-array name="textfield_type_spinner">
+        <item>Text</item>
+        <item>Number</item>
+        <item>Password</item>
+        <item>Email</item>
     </string-array>
 
     <string-array name="textfield_state_spinner">


### PR DESCRIPTION
### Thanks for starting a pull request on Andes UI!

## Motivation
InputType added to Andes Textfield

## Description
Defines the basic content type of text held in the Andes Textfield:
- Text
- Number
- Password
- Email (@)

## Affected component
Textfield

## Frontify component link
The UX team behind Andes keeps all the Andes Components inside the Frontify site. Each component has its own section. Let us know the section of the component you want to modify.

## Screenshots
![Captura de Pantalla 2020-03-30 a la(s) 17 03 44](https://user-images.githubusercontent.com/45457170/77957327-b6322300-72a9-11ea-8295-032445b9105a.png)
![Captura de Pantalla 2020-03-30 a la(s) 17 04 13](https://user-images.githubusercontent.com/45457170/77957338-b7fbe680-72a9-11ea-90d2-985a96e2ea6c.png)
![Captura de Pantalla 2020-03-30 a la(s) 17 04 47](https://user-images.githubusercontent.com/45457170/77957341-b8947d00-72a9-11ea-8c5a-79b1138b3977.png)

## Checks
Are you sure you followed all those steps? In such case, let's say with me "I solemnly declare that ...":
- [X] I have coded an example inside the Demo App,
- [ ] I have added proper tests,
- [ ] I have modified the [Changelog](https://github.com/mercadolibre/fury_andesui-android/blob/develop/CHANGELOG.md) file,
- [ ] I have updated GitHub wiki,
- [ ] I have the explicit approval of one or more members of the UX Team,
- [ ] I have updated the version in gradle.properties file.

## Change type
This is easy, let us know what this code is about:
- [ ] This code adds a new component
- [X] This code includes improvements to an existent component
- [X] This code improves or modifies ONLY the Demo App.

## Check common errors
Whether you are an Android or iOS developer and if you're still there then we'll give you a present:
https://proandroiddev.com/how-to-maximize-androids-ui-reusability-5-common-mistakes-cb2571216a9f
