### PR TITLE
Chage all when in demoapp to enum.valueOf(string)

### DIFF
--- a/demoapp/src/main/java/com/mercadolibre/android/andesui/demoapp/feature/MessageShowcaseActivity.kt
+++ b/demoapp/src/main/java/com/mercadolibre/android/andesui/demoapp/feature/MessageShowcaseActivity.kt
@@ -108,18 +108,9 @@ class MessageShowcaseActivity : AppCompatActivity() {
                     changeMessage.body = bodyText.text.toString()
                 }
 
-                when (typeSpinner.selectedItem.toString()) {
-                    "Neutral" -> changeMessage.type = AndesMessageType.NEUTRAL
-                    "Success" -> changeMessage.type = AndesMessageType.SUCCESS
-                    "Warning" -> changeMessage.type = AndesMessageType.WARNING
-                    "Error" -> changeMessage.type = AndesMessageType.ERROR
-                }
+                changeMessage.type = AndesMessageType.valueOf(typeSpinner.selectedItem.toString().toUpperCase())
 
-                when (hierarchySpinner.selectedItem.toString()) {
-                    "Loud" -> changeMessage.hierarchy = AndesMessageHierarchy.LOUD
-                    "Quiet" -> changeMessage.hierarchy = AndesMessageHierarchy.QUIET
-                }
-
+                changeMessage.hierarchy = AndesMessageHierarchy.valueOf(hierarchySpinner.selectedItem.toString().toUpperCase())
 
                 if (primaryActionText.text.toString() != "") {
                     changeMessage.setupPrimaryAction(primaryActionText.text.toString(), View.OnClickListener {

--- a/demoapp/src/main/java/com/mercadolibre/android/andesui/demoapp/feature/TextfieldShowcaseActivity.kt
+++ b/demoapp/src/main/java/com/mercadolibre/android/andesui/demoapp/feature/TextfieldShowcaseActivity.kt
@@ -92,10 +92,10 @@ class TextfieldShowcaseActivity : AppCompatActivity() {
                 stateSpinner.adapter = adapter
             }
 
-            val preffixSpinner: Spinner = layoutTextfield.findViewById(R.id.preffix_spinner)
+            val preffixSpinner: Spinner = layoutTextfield.findViewById(R.id.prefix_spinner)
             ArrayAdapter.createFromResource(
                     context,
-                    R.array.preffix_spinner,
+                    R.array.prefix_spinner,
                     android.R.layout.simple_spinner_item
             ).also { adapter ->
                 adapter.setDropDownViewResource(android.R.layout.simple_spinner_dropdown_item)
@@ -122,25 +122,11 @@ class TextfieldShowcaseActivity : AppCompatActivity() {
                 val max = counterMax.text.toString().toIntOrNull() ?: 0
                 textfield.counter = AndesTextfieldCounter(min,max)
 
-                when (stateSpinner.selectedItem.toString()) {
-                    "Enabled" -> textfield.state = AndesTextfieldState.ENABLED
-                    "Disabled" -> textfield.state = AndesTextfieldState.DISABLED
-                    "Error" -> textfield.state = AndesTextfieldState.ERROR
-                    "Readonly" -> textfield.state = AndesTextfieldState.READONLY
-                }
+                textfield.state = AndesTextfieldState.valueOf(stateSpinner.selectedItem.toString().toUpperCase())
 
-                when (preffixSpinner.selectedItem.toString()) {
-                    "Preffix" -> textfield.leftContent = AndesTextfieldLeftContent.PREFIX
-                    "Icon" -> textfield.leftContent = AndesTextfieldLeftContent.ICON
-                }
+                textfield.leftContent = AndesTextfieldLeftContent.valueOf(preffixSpinner.selectedItem.toString().toUpperCase())
 
-                when (suffixSpinner.selectedItem.toString()) {
-                    "Suffix" -> textfield.rightContent = AndesTextfieldRightContent.SUFFIX
-                    "Icon" -> textfield.rightContent = AndesTextfieldRightContent.ICON
-                    "Validated" -> textfield.rightContent = AndesTextfieldRightContent.VALIDATED
-                    "Clear" -> textfield.rightContent = AndesTextfieldRightContent.CLEAR
-                    "Action" -> textfield.rightContent = AndesTextfieldRightContent.ACTION
-                }
+                textfield.rightContent = AndesTextfieldRightContent.valueOf(suffixSpinner.selectedItem.toString().toUpperCase())
 
                 val selectedInputType = getInputTypesArray().filter { it.name == inputTypeSpinner.selectedItem.toString() }.single().value
                 textfield.inputType = selectedInputType

--- a/demoapp/src/main/res/layout/andesui_textfield_showcase_change.xml
+++ b/demoapp/src/main/res/layout/andesui_textfield_showcase_change.xml
@@ -53,14 +53,14 @@
             android:layout_marginTop="10dp" />
 
         <TextView
-            android:text="@string/andesui_demoapp_textfield_preffix_text"
+            android:text="@string/andesui_demoapp_textfield_prefix_text"
             android:textColor="@color/andes_gray_800"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
             android:layout_marginTop="@dimen/andes_textfield_container_marginTop"/>
 
         <Spinner
-            android:id="@+id/preffix_spinner"
+            android:id="@+id/prefix_spinner"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
             android:layout_marginTop="10dp" />

--- a/demoapp/src/main/res/values/strings.xml
+++ b/demoapp/src/main/res/values/strings.xml
@@ -58,7 +58,7 @@
     <string name="andesui_demoapp_clear_button">Clear</string>
     <string name="andesui_demoapp_textfiled">Andes Textfield</string>
     <string name="andesui_demoapp_textfield_state_text">State:</string>
-    <string name="andesui_demoapp_textfield_preffix_text">Preffix:</string>
+    <string name="andesui_demoapp_textfield_prefix_text">Prefix:</string>
     <string name="andesui_demoapp_textfield_suffix_text">Suffix:</string>
     <string name="andesui_demoapp_counter_text">Counter:</string>
     <string name="andesui_demoapp_counter_separator">/</string>
@@ -91,8 +91,8 @@
         <item>Action</item>
     </string-array>
 
-    <string-array name="preffix_spinner">
-        <item>Preffix</item>
+    <string-array name="prefix_spinner">
+        <item>Prefix</item>
         <item>Icon</item>
     </string-array>
 


### PR DESCRIPTION
### Thanks for starting a pull request on Andes UI!

## Motivation
Have an example of how to use enums without mapping strings

## Affected component
All of them and the demoapp too

## Frontify component link
The UX team behind Andes keeps all the Andes Components inside the Frontify site. Each component has its own section. Let us know the section of the component you want to modify.

## Checks
Are you sure you followed all those steps? In such case, let's say with me "I solemnly declare that ...":
- [X] I have coded an example inside the Demo App,
- [ ] I have added proper tests,
- [ ] I have modified the [Changelog](https://github.com/mercadolibre/fury_andesui-android/blob/develop/CHANGELOG.md) file,
- [ ] I have updated GitHub wiki,
- [ ] I have the explicit approval of one or more members of the UX Team,
- [ ] I have updated the version in gradle.properties file.

## Change type
This is easy, let us know what this code is about:
- [ ] This code adds a new component
- [ ] This code includes improvements to an existent component
- [X] This code improves or modifies ONLY the Demo App.

## Check common errors
Whether you are an Android or iOS developer and if you're still there then we'll give you a present:
https://proandroiddev.com/how-to-maximize-androids-ui-reusability-5-common-mistakes-cb2571216a9f
