### PR TITLE
Minor errors in textfield

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,10 +1,11 @@
 # v2.3.0
 ## Changed
 - Minor UX improvements in the Andes App.
+- Minor errors in textfield.
 
 # v2.2.0
 ## Changed
-- Remove modifier from AndesBadge
+- Remove modifier from AndesBadge.
 
 ## Fixed
 - Label error textfield color.

--- a/components/src/main/java/com/mercadolibre/android/andesui/textfield/AndesTextfield.kt
+++ b/components/src/main/java/com/mercadolibre/android/andesui/textfield/AndesTextfield.kt
@@ -87,8 +87,11 @@ class AndesTextfield : ConstraintLayout {
         get() = andesTextfieldAttrs.state
         set(value) {
             andesTextfieldAttrs = andesTextfieldAttrs.copy(state = value)
-            setupColorComponents(createConfig())
+            val config = createConfig()
             setupEnabledView()
+            setupColorComponents(config)
+            setupHelperComponent(config)
+            setupCounterComponent(config)
         }
 
     /**
@@ -202,7 +205,6 @@ class AndesTextfield : ConstraintLayout {
     /**
      * Creates all the views that are part of this textfield.
      * After a view is created then a view id is added to it.
-     *
      */
     private fun initComponents() {
         val container = LayoutInflater.from(context).inflate(R.layout.andes_layout_textfield, this, true)
@@ -260,13 +262,12 @@ class AndesTextfield : ConstraintLayout {
 
     /**
      * Gets data from the config to sets the color of the components regarding to the state.
-     *
      */
     private fun setupColorComponents(config: AndesTextfieldConfiguration) {
         textContainer.background = config.background
 
         iconComponent.setImageDrawable(config.icon)
-        if (config.icon != null) {
+        if (config.icon != null && state != READONLY) {
             if (!config.helperText.isNullOrEmpty()) {
                 iconComponent.visibility = View.VISIBLE
             }
@@ -288,7 +289,6 @@ class AndesTextfield : ConstraintLayout {
 
     /**
      * Gets data from the config and sets to the Label component.
-     *
      */
     private fun setupLabelComponent(config: AndesTextfieldConfiguration) {
         if (config.labelText == null || config.labelText.isEmpty()) {
@@ -302,10 +302,9 @@ class AndesTextfield : ConstraintLayout {
 
     /**
      * Gets data from the config and sets to the Helper component.
-     *
      */
     private fun setupHelperComponent(config: AndesTextfieldConfiguration) {
-        if (config.helperText == null || config.helperText.isEmpty()) {
+        if (config.helperText == null || config.helperText.isEmpty() || state == READONLY) {
             helperComponent.visibility = View.GONE
         } else {
             helperComponent.visibility = View.VISIBLE
@@ -316,10 +315,9 @@ class AndesTextfield : ConstraintLayout {
 
     /**
      * Gets data from the config and sets to the Counter component.
-     *
      */
     private fun setupCounterComponent(config: AndesTextfieldConfiguration) {
-        if (config.counterLength != 0) {
+        if (config.counterLength != 0 && state != READONLY) {
             counterComponent.visibility = View.VISIBLE
             counterComponent.setTextSize(TypedValue.COMPLEX_UNIT_PX, config.counterSize)
             counterComponent.text = resources.getString(R.string.andes_textfield_counter_text, 0, config.counterLength)
@@ -343,24 +341,22 @@ class AndesTextfield : ConstraintLayout {
 
     /**
      * Gets data from the config and sets to the Place Holder component.
-     *
      */
     private fun setupPlaceHolderComponent(config: AndesTextfieldConfiguration) {
-        if (config.placeHolderText != null) {
-            textComponent.hint = config.placeHolderText
-            textComponent.typeface = config.typeface
-        }
+        textComponent.hint = config.placeHolderText
+        textComponent.typeface = config.typeface
     }
 
     /**
      * Gets data from the config and sets to the Left component.
      */
     private fun setupLeftComponent(config: AndesTextfieldConfiguration) {
+        setupMarginStartTextComponent()
+
         if (config.leftComponent != null) {
             leftComponent.removeAllViews()
             leftComponent.addView(config.leftComponent)
-
-            val params = leftComponent.layoutParams as ConstraintLayout.LayoutParams
+            val params = leftComponent.layoutParams as LayoutParams
             params.marginStart = config.leftComponentLeftMargin!!
             params.marginEnd = config.leftComponentRightMargin!!
             leftComponent.layoutParams = params
@@ -371,6 +367,16 @@ class AndesTextfield : ConstraintLayout {
         }
     }
 
+    private fun setupMarginStartTextComponent() {
+        val params = textComponent.layoutParams as LayoutParams
+        if (state == READONLY) {
+            params.goneStartMargin = context.resources.getDimension(R.dimen.andes_textfield_label_paddingLeft).toInt()
+        } else {
+            params.goneStartMargin = context.resources.getDimension(R.dimen.andes_textfield_margin).toInt()
+        }
+        textComponent.layoutParams = params
+    }
+
     /**
      * Gets data from the config and sets to the right component.
      */
@@ -379,7 +385,7 @@ class AndesTextfield : ConstraintLayout {
             rightComponent.removeAllViews()
             rightComponent.addView(config.rightComponent)
 
-            val params = rightComponent.layoutParams as ConstraintLayout.LayoutParams
+            val params = rightComponent.layoutParams as LayoutParams
             params.marginStart = config.rightComponentLeftMargin!!
             params.marginEnd = config.rightComponentRightMargin!!
             rightComponent.layoutParams = params
@@ -424,6 +430,7 @@ class AndesTextfield : ConstraintLayout {
         rightContent = AndesTextfieldRightContent.ACTION
         val action: AndesButton = rightComponent.getChildAt(0) as AndesButton
         action.text = text
+        action.isEnabled = state != READONLY && state != DISABLED
         action.setOnClickListener(onClickListener)
     }
 

--- a/components/src/main/java/com/mercadolibre/android/andesui/textfield/content/AndesTextfieldContentInterface.kt
+++ b/components/src/main/java/com/mercadolibre/android/andesui/textfield/content/AndesTextfieldContentInterface.kt
@@ -44,13 +44,7 @@ internal object AndesSuffixTextfieldContent : AndesTextfieldContentInterface() {
 }
 
 internal object AndesPrefixTextfieldContent : AndesTextfieldContentInterface() {
-    override fun leftMargin(context: Context, state: AndesTextfieldState): Int {
-        return if (state == AndesTextfieldState.READONLY) {
-            context.resources.getDimension(R.dimen.andes_textfield_label_paddingLeft).toInt()
-        } else {
-            context.resources.getDimension(R.dimen.andes_textfield_indeterminate_left_margin).toInt()
-        }
-    }
+    override fun leftMargin(context: Context, state: AndesTextfieldState): Int = state.state.leftMargin(context)
 
     override fun rightMargin(context: Context): Int = context.resources.getDimension(R.dimen.andes_textfield_prefix_right_margin).toInt()
 
@@ -67,13 +61,7 @@ internal object AndesPrefixTextfieldContent : AndesTextfieldContentInterface() {
 internal object AndesIconTextfieldContent : AndesTextfieldContentInterface() {
     private const val ICON_CONTENT_DESCRIPTION = "icon"
 
-    override fun leftMargin(context: Context, state: AndesTextfieldState): Int {
-        return if (state == AndesTextfieldState.READONLY) {
-            context.resources.getDimension(R.dimen.andes_textfield_label_paddingLeft).toInt()
-        } else {
-            context.resources.getDimension(R.dimen.andes_textfield_indeterminate_left_margin).toInt()
-        }
-    }
+    override fun leftMargin(context: Context, state: AndesTextfieldState): Int = state.state.leftMargin(context)
 
     override fun rightMargin(context: Context): Int = context.resources.getDimension(R.dimen.andes_textfield_icon_right_margin).toInt()
 
@@ -89,13 +77,7 @@ internal object AndesIconTextfieldContent : AndesTextfieldContentInterface() {
 }
 
 internal object AndesTooltipTextfieldContent : AndesTextfieldContentInterface() {
-    override fun leftMargin(context: Context, state: AndesTextfieldState): Int {
-        return if (state == AndesTextfieldState.READONLY) {
-            context.resources.getDimension(R.dimen.andes_textfield_label_paddingLeft).toInt()
-        } else {
-            context.resources.getDimension(R.dimen.andes_textfield_indeterminate_left_margin).toInt()
-        }
-    }
+    override fun leftMargin(context: Context, state: AndesTextfieldState): Int = state.state.leftMargin(context)
 
     override fun rightMargin(context: Context): Int = context.resources.getDimension(R.dimen.andes_textfield_tooltip_right_margin).toInt()
 
@@ -107,13 +89,7 @@ internal object AndesTooltipTextfieldContent : AndesTextfieldContentInterface() 
 internal object AndesValidatedTextfieldContent : AndesTextfieldContentInterface() {
     private const val VALIDATED_CONTENT_DESCRIPTION = "validated"
 
-    override fun leftMargin(context: Context, state: AndesTextfieldState): Int {
-        return if (state == AndesTextfieldState.READONLY) {
-            context.resources.getDimension(R.dimen.andes_textfield_label_paddingLeft).toInt()
-        } else {
-            context.resources.getDimension(R.dimen.andes_textfield_indeterminate_left_margin).toInt()
-        }
-    }
+    override fun leftMargin(context: Context, state: AndesTextfieldState): Int = state.state.leftMargin(context)
 
     override fun rightMargin(context: Context): Int = context.resources.getDimension(R.dimen.andes_textfield_validated_right_margin).toInt()
 
@@ -159,13 +135,7 @@ internal object AndesActionTextfieldContent : AndesTextfieldContentInterface() {
 }
 
 internal object AndesIndeterminateTextfieldContent : AndesTextfieldContentInterface() {
-    override fun leftMargin(context: Context, state: AndesTextfieldState): Int {
-        return if (state == AndesTextfieldState.READONLY) {
-            context.resources.getDimension(R.dimen.andes_textfield_label_paddingLeft).toInt()
-        } else {
-            context.resources.getDimension(R.dimen.andes_textfield_indeterminate_left_margin).toInt()
-        }
-    }
+    override fun leftMargin(context: Context, state: AndesTextfieldState): Int = state.state.leftMargin(context)
 
     override fun rightMargin(context: Context): Int = context.resources.getDimension(R.dimen.andes_textfield_indeterminate_right_margin).toInt()
 

--- a/components/src/main/java/com/mercadolibre/android/andesui/textfield/content/AndesTextfieldContentInterface.kt
+++ b/components/src/main/java/com/mercadolibre/android/andesui/textfield/content/AndesTextfieldContentInterface.kt
@@ -13,6 +13,7 @@ import com.mercadolibre.android.andesui.button.size.AndesButtonSize
 import com.mercadolibre.android.andesui.color.toAndesColor
 import com.mercadolibre.android.andesui.color.toColor
 import com.mercadolibre.android.andesui.icons.IconProvider
+import com.mercadolibre.android.andesui.textfield.state.AndesTextfieldState
 import com.mercadolibre.android.andesui.typeface.getFontOrDefault
 import com.mercadolibre.android.andesui.utils.buildColoredBitmapDrawable
 
@@ -23,12 +24,12 @@ import com.mercadolibre.android.andesui.utils.buildColoredBitmapDrawable
  */
 internal sealed class AndesTextfieldContentInterface {
     abstract fun component(context: Context): View
-    abstract fun leftMargin(context: Context): Int
+    abstract fun leftMargin(context: Context, state: AndesTextfieldState): Int
     abstract fun rightMargin(context: Context): Int
 }
 
 internal object AndesSuffixTextfieldContent : AndesTextfieldContentInterface() {
-    override fun leftMargin(context: Context): Int = context.resources.getDimension(R.dimen.andes_textfield_suffix_left_margin).toInt()
+    override fun leftMargin(context: Context, state: AndesTextfieldState): Int = context.resources.getDimension(R.dimen.andes_textfield_suffix_left_margin).toInt()
 
     override fun rightMargin(context: Context): Int = context.resources.getDimension(R.dimen.andes_textfield_suffix_right_margin).toInt()
 
@@ -43,7 +44,13 @@ internal object AndesSuffixTextfieldContent : AndesTextfieldContentInterface() {
 }
 
 internal object AndesPrefixTextfieldContent : AndesTextfieldContentInterface() {
-    override fun leftMargin(context: Context): Int = context.resources.getDimension(R.dimen.andes_textfield_prefix_left_margin).toInt()
+    override fun leftMargin(context: Context, state: AndesTextfieldState): Int {
+        return if (state == AndesTextfieldState.READONLY) {
+            context.resources.getDimension(R.dimen.andes_textfield_label_paddingLeft).toInt()
+        } else {
+            context.resources.getDimension(R.dimen.andes_textfield_indeterminate_left_margin).toInt()
+        }
+    }
 
     override fun rightMargin(context: Context): Int = context.resources.getDimension(R.dimen.andes_textfield_prefix_right_margin).toInt()
 
@@ -60,7 +67,13 @@ internal object AndesPrefixTextfieldContent : AndesTextfieldContentInterface() {
 internal object AndesIconTextfieldContent : AndesTextfieldContentInterface() {
     private const val ICON_CONTENT_DESCRIPTION = "icon"
 
-    override fun leftMargin(context: Context): Int = context.resources.getDimension(R.dimen.andes_textfield_icon_left_margin).toInt()
+    override fun leftMargin(context: Context, state: AndesTextfieldState): Int {
+        return if (state == AndesTextfieldState.READONLY) {
+            context.resources.getDimension(R.dimen.andes_textfield_label_paddingLeft).toInt()
+        } else {
+            context.resources.getDimension(R.dimen.andes_textfield_indeterminate_left_margin).toInt()
+        }
+    }
 
     override fun rightMargin(context: Context): Int = context.resources.getDimension(R.dimen.andes_textfield_icon_right_margin).toInt()
 
@@ -76,7 +89,13 @@ internal object AndesIconTextfieldContent : AndesTextfieldContentInterface() {
 }
 
 internal object AndesTooltipTextfieldContent : AndesTextfieldContentInterface() {
-    override fun leftMargin(context: Context): Int = context.resources.getDimension(R.dimen.andes_textfield_tooltip_left_margin).toInt()
+    override fun leftMargin(context: Context, state: AndesTextfieldState): Int {
+        return if (state == AndesTextfieldState.READONLY) {
+            context.resources.getDimension(R.dimen.andes_textfield_label_paddingLeft).toInt()
+        } else {
+            context.resources.getDimension(R.dimen.andes_textfield_indeterminate_left_margin).toInt()
+        }
+    }
 
     override fun rightMargin(context: Context): Int = context.resources.getDimension(R.dimen.andes_textfield_tooltip_right_margin).toInt()
 
@@ -88,7 +107,13 @@ internal object AndesTooltipTextfieldContent : AndesTextfieldContentInterface() 
 internal object AndesValidatedTextfieldContent : AndesTextfieldContentInterface() {
     private const val VALIDATED_CONTENT_DESCRIPTION = "validated"
 
-    override fun leftMargin(context: Context): Int = context.resources.getDimension(R.dimen.andes_textfield_validated_left_margin).toInt()
+    override fun leftMargin(context: Context, state: AndesTextfieldState): Int {
+        return if (state == AndesTextfieldState.READONLY) {
+            context.resources.getDimension(R.dimen.andes_textfield_label_paddingLeft).toInt()
+        } else {
+            context.resources.getDimension(R.dimen.andes_textfield_indeterminate_left_margin).toInt()
+        }
+    }
 
     override fun rightMargin(context: Context): Int = context.resources.getDimension(R.dimen.andes_textfield_validated_right_margin).toInt()
 
@@ -107,7 +132,7 @@ internal object AndesValidatedTextfieldContent : AndesTextfieldContentInterface(
 internal object AndesClearTextfieldContent : AndesTextfieldContentInterface() {
     private const val CLEAR_CONTENT_DESCRIPTION = "clear"
 
-    override fun leftMargin(context: Context): Int = context.resources.getDimension(R.dimen.andes_textfield_clear_left_margin).toInt()
+    override fun leftMargin(context: Context, state: AndesTextfieldState): Int = context.resources.getDimension(R.dimen.andes_textfield_clear_left_margin).toInt()
 
     override fun rightMargin(context: Context): Int = context.resources.getDimension(R.dimen.andes_textfield_clear_right_margin).toInt()
 
@@ -124,7 +149,7 @@ internal object AndesClearTextfieldContent : AndesTextfieldContentInterface() {
 }
 
 internal object AndesActionTextfieldContent : AndesTextfieldContentInterface() {
-    override fun leftMargin(context: Context): Int = context.resources.getDimension(R.dimen.andes_textfield_action_left_margin).toInt()
+    override fun leftMargin(context: Context, state: AndesTextfieldState): Int = context.resources.getDimension(R.dimen.andes_textfield_action_left_margin).toInt()
 
     override fun rightMargin(context: Context): Int = context.resources.getDimension(R.dimen.andes_textfield_action_right_margin).toInt()
 
@@ -134,7 +159,13 @@ internal object AndesActionTextfieldContent : AndesTextfieldContentInterface() {
 }
 
 internal object AndesIndeterminateTextfieldContent : AndesTextfieldContentInterface() {
-    override fun leftMargin(context: Context): Int = context.resources.getDimension(R.dimen.andes_textfield_indeterminate_left_margin).toInt()
+    override fun leftMargin(context: Context, state: AndesTextfieldState): Int {
+        return if (state == AndesTextfieldState.READONLY) {
+            context.resources.getDimension(R.dimen.andes_textfield_label_paddingLeft).toInt()
+        } else {
+            context.resources.getDimension(R.dimen.andes_textfield_indeterminate_left_margin).toInt()
+        }
+    }
 
     override fun rightMargin(context: Context): Int = context.resources.getDimension(R.dimen.andes_textfield_indeterminate_right_margin).toInt()
 
@@ -144,7 +175,7 @@ internal object AndesIndeterminateTextfieldContent : AndesTextfieldContentInterf
 }
 
 internal object AndesCheckboxTextfieldContent : AndesTextfieldContentInterface() {
-    override fun leftMargin(context: Context): Int = 0
+    override fun leftMargin(context: Context, state: AndesTextfieldState): Int = 0
 
     override fun rightMargin(context: Context): Int = 0
 

--- a/components/src/main/java/com/mercadolibre/android/andesui/textfield/content/AndesTextfieldContentInterface.kt
+++ b/components/src/main/java/com/mercadolibre/android/andesui/textfield/content/AndesTextfieldContentInterface.kt
@@ -14,6 +14,7 @@ import com.mercadolibre.android.andesui.color.toAndesColor
 import com.mercadolibre.android.andesui.color.toColor
 import com.mercadolibre.android.andesui.icons.IconProvider
 import com.mercadolibre.android.andesui.textfield.state.AndesTextfieldState
+import com.mercadolibre.android.andesui.textfield.state.AndesTextfieldStateInterface
 import com.mercadolibre.android.andesui.typeface.getFontOrDefault
 import com.mercadolibre.android.andesui.utils.buildColoredBitmapDrawable
 
@@ -24,12 +25,12 @@ import com.mercadolibre.android.andesui.utils.buildColoredBitmapDrawable
  */
 internal sealed class AndesTextfieldContentInterface {
     abstract fun component(context: Context): View
-    abstract fun leftMargin(context: Context, state: AndesTextfieldState): Int
+    abstract fun leftMargin(context: Context, state: AndesTextfieldStateInterface): Int
     abstract fun rightMargin(context: Context): Int
 }
 
 internal object AndesSuffixTextfieldContent : AndesTextfieldContentInterface() {
-    override fun leftMargin(context: Context, state: AndesTextfieldState): Int = context.resources.getDimension(R.dimen.andes_textfield_suffix_left_margin).toInt()
+    override fun leftMargin(context: Context, state: AndesTextfieldStateInterface): Int = context.resources.getDimension(R.dimen.andes_textfield_suffix_left_margin).toInt()
 
     override fun rightMargin(context: Context): Int = context.resources.getDimension(R.dimen.andes_textfield_suffix_right_margin).toInt()
 
@@ -44,7 +45,7 @@ internal object AndesSuffixTextfieldContent : AndesTextfieldContentInterface() {
 }
 
 internal object AndesPrefixTextfieldContent : AndesTextfieldContentInterface() {
-    override fun leftMargin(context: Context, state: AndesTextfieldState): Int = state.state.leftMargin(context)
+    override fun leftMargin(context: Context, state: AndesTextfieldStateInterface): Int = state.leftMargin(context)
 
     override fun rightMargin(context: Context): Int = context.resources.getDimension(R.dimen.andes_textfield_prefix_right_margin).toInt()
 
@@ -61,7 +62,7 @@ internal object AndesPrefixTextfieldContent : AndesTextfieldContentInterface() {
 internal object AndesIconTextfieldContent : AndesTextfieldContentInterface() {
     private const val ICON_CONTENT_DESCRIPTION = "icon"
 
-    override fun leftMargin(context: Context, state: AndesTextfieldState): Int = state.state.leftMargin(context)
+    override fun leftMargin(context: Context, state: AndesTextfieldStateInterface): Int = state.leftMargin(context)
 
     override fun rightMargin(context: Context): Int = context.resources.getDimension(R.dimen.andes_textfield_icon_right_margin).toInt()
 
@@ -77,7 +78,7 @@ internal object AndesIconTextfieldContent : AndesTextfieldContentInterface() {
 }
 
 internal object AndesTooltipTextfieldContent : AndesTextfieldContentInterface() {
-    override fun leftMargin(context: Context, state: AndesTextfieldState): Int = state.state.leftMargin(context)
+    override fun leftMargin(context: Context, state: AndesTextfieldStateInterface): Int = state.leftMargin(context)
 
     override fun rightMargin(context: Context): Int = context.resources.getDimension(R.dimen.andes_textfield_tooltip_right_margin).toInt()
 
@@ -89,7 +90,7 @@ internal object AndesTooltipTextfieldContent : AndesTextfieldContentInterface() 
 internal object AndesValidatedTextfieldContent : AndesTextfieldContentInterface() {
     private const val VALIDATED_CONTENT_DESCRIPTION = "validated"
 
-    override fun leftMargin(context: Context, state: AndesTextfieldState): Int = state.state.leftMargin(context)
+    override fun leftMargin(context: Context, state: AndesTextfieldStateInterface): Int = state.leftMargin(context)
 
     override fun rightMargin(context: Context): Int = context.resources.getDimension(R.dimen.andes_textfield_validated_right_margin).toInt()
 
@@ -108,7 +109,7 @@ internal object AndesValidatedTextfieldContent : AndesTextfieldContentInterface(
 internal object AndesClearTextfieldContent : AndesTextfieldContentInterface() {
     private const val CLEAR_CONTENT_DESCRIPTION = "clear"
 
-    override fun leftMargin(context: Context, state: AndesTextfieldState): Int = context.resources.getDimension(R.dimen.andes_textfield_clear_left_margin).toInt()
+    override fun leftMargin(context: Context, state: AndesTextfieldStateInterface): Int = context.resources.getDimension(R.dimen.andes_textfield_clear_left_margin).toInt()
 
     override fun rightMargin(context: Context): Int = context.resources.getDimension(R.dimen.andes_textfield_clear_right_margin).toInt()
 
@@ -125,7 +126,7 @@ internal object AndesClearTextfieldContent : AndesTextfieldContentInterface() {
 }
 
 internal object AndesActionTextfieldContent : AndesTextfieldContentInterface() {
-    override fun leftMargin(context: Context, state: AndesTextfieldState): Int = context.resources.getDimension(R.dimen.andes_textfield_action_left_margin).toInt()
+    override fun leftMargin(context: Context, state: AndesTextfieldStateInterface): Int = context.resources.getDimension(R.dimen.andes_textfield_action_left_margin).toInt()
 
     override fun rightMargin(context: Context): Int = context.resources.getDimension(R.dimen.andes_textfield_action_right_margin).toInt()
 
@@ -135,7 +136,7 @@ internal object AndesActionTextfieldContent : AndesTextfieldContentInterface() {
 }
 
 internal object AndesIndeterminateTextfieldContent : AndesTextfieldContentInterface() {
-    override fun leftMargin(context: Context, state: AndesTextfieldState): Int = state.state.leftMargin(context)
+    override fun leftMargin(context: Context, state: AndesTextfieldStateInterface): Int = state.leftMargin(context)
 
     override fun rightMargin(context: Context): Int = context.resources.getDimension(R.dimen.andes_textfield_indeterminate_right_margin).toInt()
 
@@ -145,7 +146,7 @@ internal object AndesIndeterminateTextfieldContent : AndesTextfieldContentInterf
 }
 
 internal object AndesCheckboxTextfieldContent : AndesTextfieldContentInterface() {
-    override fun leftMargin(context: Context, state: AndesTextfieldState): Int = 0
+    override fun leftMargin(context: Context, state: AndesTextfieldStateInterface): Int = 0
 
     override fun rightMargin(context: Context): Int = 0
 

--- a/components/src/main/java/com/mercadolibre/android/andesui/textfield/factory/AndesTextfieldConfigurationFactory.kt
+++ b/components/src/main/java/com/mercadolibre/android/andesui/textfield/factory/AndesTextfieldConfigurationFactory.kt
@@ -7,6 +7,7 @@ import android.view.View
 import com.mercadolibre.android.andesui.R
 import com.mercadolibre.android.andesui.color.AndesColor
 import com.mercadolibre.android.andesui.textfield.content.AndesTextfieldContentInterface
+import com.mercadolibre.android.andesui.textfield.state.AndesTextfieldState
 import com.mercadolibre.android.andesui.textfield.state.AndesTextfieldStateInterface
 import com.mercadolibre.android.andesui.typeface.getFontOrDefault
 
@@ -53,16 +54,16 @@ internal object AndesTextfieldConfigurationFactory {
                     counterColor = resolveCounterTextColor(state.state),
                     counterSize = resolveCounterSize(context),
                     counterLength = counter,
-                    placeHolderColor = resolvePlaceHolderColor(state.state, context),
+                    placeHolderColor = resolvePlaceHolderColor(state.state),
                     placeHolderSize = resolvePlaceHolderSize(context),
                     placeHolderText = placeholder,
                     typeface = resolveTypeface(context),
                     icon = resolveIcon(context, state.state),
                     leftComponent = resolveLeftComponent(context, leftContent?.leftContent),
                     rightComponent = resolveRightComponent(context, rightContent?.rightContent),
-                    leftComponentLeftMargin = resolveLeftComponentLeftMargin(context, leftContent?.leftContent),
+                    leftComponentLeftMargin = resolveLeftComponentLeftMargin(context, andesTextfieldAttrs.state, leftContent?.leftContent),
                     leftComponentRightMargin = resolveLeftComponentRightMargin(context, leftContent?.leftContent),
-                    rightComponentLeftMargin = resolveRightComponentLeftMargin(context, rightContent?.rightContent),
+                    rightComponentLeftMargin = resolveRightComponentLeftMargin(context, andesTextfieldAttrs.state, rightContent?.rightContent),
                     rightComponentRightMargin = resolveRightComponentRightMargin(context, rightContent?.rightContent)
             )
         }
@@ -84,7 +85,7 @@ internal object AndesTextfieldConfigurationFactory {
                     counterSize = resolveCounterSize(context),
                     counterLength = counter,
                     placeHolderText = placeholder,
-                    placeHolderColor = resolvePlaceHolderColor(state.state, context),
+                    placeHolderColor = resolvePlaceHolderColor(state.state),
                     placeHolderSize = resolvePlaceHolderSize(context),
                     typeface = resolveTypeface(context),
                     icon = resolveIcon(context, state.state),
@@ -103,13 +104,14 @@ internal object AndesTextfieldConfigurationFactory {
     private fun resolveCounterSize(context: Context): Float = context.resources.getDimension(R.dimen.andes_textfield_counter_textSize)
     private fun resolveTypeface(context: Context) = context.getFontOrDefault(R.font.andes_font_regular)
     private fun resolveIcon(context: Context, state: AndesTextfieldStateInterface): Drawable? = state.icon(context)
-    private fun resolvePlaceHolderColor(state: AndesTextfieldStateInterface, context: Context): AndesColor = state.placeholderColor()
+    private fun resolvePlaceHolderColor(state: AndesTextfieldStateInterface): AndesColor = state.placeholderColor()
     private fun resolvePlaceHolderSize(context: Context): Float = context.resources.getDimension(R.dimen.andes_textfield_placeholder_textSize)
     private fun resolveLeftComponent(context: Context, leftContent: AndesTextfieldContentInterface?): View? = leftContent?.component(context)
     private fun resolveRightComponent(context: Context, rightContent: AndesTextfieldContentInterface?): View? = rightContent?.component(context)
-    private fun resolveLeftComponentLeftMargin(context: Context, leftContent: AndesTextfieldContentInterface?): Int? = leftContent?.leftMargin(context)
+    private fun resolveLeftComponentLeftMargin(context: Context, state: AndesTextfieldState, leftContent: AndesTextfieldContentInterface?): Int? = leftContent?.leftMargin(context, state)
     private fun resolveLeftComponentRightMargin(context: Context, leftContent: AndesTextfieldContentInterface?): Int? = leftContent?.rightMargin(context)
-    private fun resolveRightComponentLeftMargin(context: Context, rightContent: AndesTextfieldContentInterface?): Int? = rightContent?.leftMargin(context)
+    private fun resolveRightComponentLeftMargin(context: Context, state: AndesTextfieldState, rightContent: AndesTextfieldContentInterface?): Int? = rightContent?.leftMargin(context, state)
     private fun resolveRightComponentRightMargin(context: Context, rightContent: AndesTextfieldContentInterface?): Int? = rightContent?.rightMargin(context)
     private fun resolveHelper(state: AndesTextfieldStateInterface, helper: String?): String? = state.helper(helper)
+
 }

--- a/components/src/main/java/com/mercadolibre/android/andesui/textfield/factory/AndesTextfieldConfigurationFactory.kt
+++ b/components/src/main/java/com/mercadolibre/android/andesui/textfield/factory/AndesTextfieldConfigurationFactory.kt
@@ -61,9 +61,9 @@ internal object AndesTextfieldConfigurationFactory {
                     icon = resolveIcon(context, state.state),
                     leftComponent = resolveLeftComponent(context, leftContent?.leftContent),
                     rightComponent = resolveRightComponent(context, rightContent?.rightContent),
-                    leftComponentLeftMargin = resolveLeftComponentLeftMargin(context, andesTextfieldAttrs.state, leftContent?.leftContent),
+                    leftComponentLeftMargin = resolveLeftComponentLeftMargin(context, andesTextfieldAttrs.state.state, leftContent?.leftContent),
                     leftComponentRightMargin = resolveLeftComponentRightMargin(context, leftContent?.leftContent),
-                    rightComponentLeftMargin = resolveRightComponentLeftMargin(context, andesTextfieldAttrs.state, rightContent?.rightContent),
+                    rightComponentLeftMargin = resolveRightComponentLeftMargin(context, andesTextfieldAttrs.state.state, rightContent?.rightContent),
                     rightComponentRightMargin = resolveRightComponentRightMargin(context, rightContent?.rightContent)
             )
         }
@@ -108,9 +108,9 @@ internal object AndesTextfieldConfigurationFactory {
     private fun resolvePlaceHolderSize(context: Context): Float = context.resources.getDimension(R.dimen.andes_textfield_placeholder_textSize)
     private fun resolveLeftComponent(context: Context, leftContent: AndesTextfieldContentInterface?): View? = leftContent?.component(context)
     private fun resolveRightComponent(context: Context, rightContent: AndesTextfieldContentInterface?): View? = rightContent?.component(context)
-    private fun resolveLeftComponentLeftMargin(context: Context, state: AndesTextfieldState, leftContent: AndesTextfieldContentInterface?): Int? = leftContent?.leftMargin(context, state)
+    private fun resolveLeftComponentLeftMargin(context: Context, state: AndesTextfieldStateInterface, leftContent: AndesTextfieldContentInterface?): Int? = leftContent?.leftMargin(context, state)
     private fun resolveLeftComponentRightMargin(context: Context, leftContent: AndesTextfieldContentInterface?): Int? = leftContent?.rightMargin(context)
-    private fun resolveRightComponentLeftMargin(context: Context, state: AndesTextfieldState, rightContent: AndesTextfieldContentInterface?): Int? = rightContent?.leftMargin(context, state)
+    private fun resolveRightComponentLeftMargin(context: Context, state: AndesTextfieldStateInterface, rightContent: AndesTextfieldContentInterface?): Int? = rightContent?.leftMargin(context, state)
     private fun resolveRightComponentRightMargin(context: Context, rightContent: AndesTextfieldContentInterface?): Int? = rightContent?.rightMargin(context)
     private fun resolveHelper(state: AndesTextfieldStateInterface, helper: String?): String? = state.helper(helper)
 

--- a/components/src/main/java/com/mercadolibre/android/andesui/textfield/state/AndesTextfieldState.kt
+++ b/components/src/main/java/com/mercadolibre/android/andesui/textfield/state/AndesTextfieldState.kt
@@ -10,9 +10,9 @@ package com.mercadolibre.android.andesui.textfield.state
  */
 enum class AndesTextfieldState {
     IDLE,
-        ERROR,
-        DISABLED,
-        READONLY;
+    ERROR,
+    DISABLED,
+    READONLY;
 
     companion object {
         fun fromString(value: String): AndesTextfieldState = valueOf(value.toUpperCase())

--- a/components/src/main/java/com/mercadolibre/android/andesui/textfield/state/AndesTextfieldStateInterface.kt
+++ b/components/src/main/java/com/mercadolibre/android/andesui/textfield/state/AndesTextfieldStateInterface.kt
@@ -27,6 +27,7 @@ internal sealed class AndesTextfieldStateInterface {
     abstract fun helpersColor(): AndesColor
     abstract fun typeFace(context: Context): Typeface
     abstract fun helper(helper: String?): String?
+    abstract fun leftMargin(context: Context): Int
 }
 
 internal object AndesIdleTextfieldState : AndesTextfieldStateInterface() {
@@ -35,6 +36,7 @@ internal object AndesIdleTextfieldState : AndesTextfieldStateInterface() {
     override fun helpersColor(): AndesColor = R.color.andes_gray_450.toAndesColor()
     override fun typeFace(context: Context): Typeface = context.getFontOrDefault(R.font.andes_font_regular)
     override fun helper(helper: String?): String? = helper
+    override fun leftMargin(context: Context): Int = context.resources.getDimension(R.dimen.andes_textfield_indeterminate_left_margin).toInt()
 
     override fun backgroundColor(context: Context): Drawable {
         return StateListDrawable().apply {
@@ -53,6 +55,7 @@ internal object AndesErrorTextfieldState : AndesTextfieldStateInterface() {
     override fun helpersColor(): AndesColor = R.color.andes_red_500.toAndesColor()
     override fun typeFace(context: Context) = context.getFontOrDefault(R.font.andes_font_semibold)
     override fun helper(helper: String?): String? = helper
+    override fun leftMargin(context: Context): Int = context.resources.getDimension(R.dimen.andes_textfield_indeterminate_left_margin).toInt()
 
     override fun backgroundColor(context: Context): Drawable {
         return StateListDrawable().apply {
@@ -77,6 +80,7 @@ internal object AndesDisabledTextfieldState : AndesTextfieldStateInterface() {
     override fun helpersColor(): AndesColor = R.color.andes_gray_250.toAndesColor()
     override fun typeFace(context: Context): Typeface = context.getFontOrDefault(R.font.andes_font_regular)
     override fun helper(helper: String?): String? = helper
+    override fun leftMargin(context: Context): Int = context.resources.getDimension(R.dimen.andes_textfield_indeterminate_left_margin).toInt()
 
     override fun backgroundColor(context: Context): Drawable {
         return createGradientDrawableWithDash(context, context.resources.getDimension(R.dimen.andes_textfield_simple_stroke).toInt(), R.color.andes_gray_200.toColor(context), context.resources.getDimension(R.dimen.andes_textfield_dash))
@@ -91,6 +95,7 @@ internal object AndesReadonlyTextfieldState : AndesTextfieldStateInterface() {
     override fun helpersColor(): AndesColor = R.color.andes_gray_250.toAndesColor()
     override fun typeFace(context: Context): Typeface = context.getFontOrDefault(R.font.andes_font_regular)
     override fun helper(helper: String?): String? = null
+    override fun leftMargin(context: Context): Int = context.resources.getDimension(R.dimen.andes_textfield_label_paddingLeft).toInt()
 
     override fun backgroundColor(context: Context): Drawable = createGradientDrawable(context, 0, 0, R.color.andes_transparent.toColor(context))
 

--- a/components/src/main/res/textfield/layout/andes_layout_textfield.xml
+++ b/components/src/main/res/textfield/layout/andes_layout_textfield.xml
@@ -48,8 +48,8 @@
             app:layout_constraintEnd_toStartOf="@+id/andes_textfield_right_component"
             app:layout_constraintStart_toEndOf="@+id/andes_textfield_left_component"
             app:layout_constraintTop_toTopOf="parent"
-            app:layout_goneMarginEnd="12dp"
-            app:layout_goneMarginStart="12dp" />
+            app:layout_goneMarginEnd="@dimen/andes_textfield_margin"
+            app:layout_goneMarginStart="@dimen/andes_textfield_margin" />
 
         <FrameLayout
             android:id="@+id/andes_textfield_right_component"

--- a/components/src/main/res/textfield/values/dimens_textfield.xml
+++ b/components/src/main/res/textfield/values/dimens_textfield.xml
@@ -40,6 +40,8 @@
     <dimen name="andes_textfield_action_left_margin">8dp</dimen>
     <dimen name="andes_textfield_action_right_margin">8dp</dimen>
 
+    <dimen name="andes_textfield_margin">12dp</dimen>
+
     <dimen name="andes_textfield_indeterminate_left_margin">12dp</dimen>
     <dimen name="andes_textfield_indeterminate_right_margin">12dp</dimen>
 

--- a/components/src/main/res/textfield/values/strings.xml
+++ b/components/src/main/res/textfield/values/strings.xml
@@ -3,7 +3,7 @@
     <string name="andes_textfield_label_text">Label</string>
     <string name="andes_textfield_helper_text">Helper text</string>
     <string name="andes_textfield_counter_text">%1$d/%2$d</string>
-    <string name="andes_textfield_placeholder_text">Input text</string>
+    <string name="andes_textfield_placeholder_text">Placeholder</string>
     <string name="andes_suffix_hint">Suffix</string>
     <string name="andes_prefix_hint">Prefix</string>
 </resources>

--- a/components/src/test/java/com/mercadolibre/android/andesui/textfield/AndesTexfieldContentInterfaceTest.kt
+++ b/components/src/test/java/com/mercadolibre/android/andesui/textfield/AndesTexfieldContentInterfaceTest.kt
@@ -63,7 +63,7 @@ class AndesTextfieldContentInterfaceTest {
         suffix.setTextColor(R.color.andes_gray_450.toColor(context))
         suffix.text = context.getString(R.string.andes_suffix_hint)
 
-        assertEquals(context.resources.getDimension(R.dimen.andes_textfield_suffix_left_margin).toInt(), contentInterface.leftMargin(context, AndesTextfieldState.IDLE))
+        assertEquals(context.resources.getDimension(R.dimen.andes_textfield_suffix_left_margin).toInt(), contentInterface.leftMargin(context, AndesTextfieldState.IDLE.state))
         assertEquals(context.resources.getDimension(R.dimen.andes_textfield_suffix_right_margin).toInt(), contentInterface.rightMargin(context))
         assertThat(contentInterface.component(context)).isEqualToComparingOnlyGivenFields(suffix)
     }
@@ -75,7 +75,7 @@ class AndesTextfieldContentInterfaceTest {
         prefix.setTextColor(R.color.andes_gray_450.toColor(context))
         prefix.text = context.getString(R.string.andes_prefix_hint)
 
-        assertEquals(context.resources.getDimension(R.dimen.andes_textfield_prefix_left_margin).toInt(), contentInterface.leftMargin(context, AndesTextfieldState.IDLE))
+        assertEquals(context.resources.getDimension(R.dimen.andes_textfield_prefix_left_margin).toInt(), contentInterface.leftMargin(context, AndesTextfieldState.IDLE.state))
         assertEquals(context.resources.getDimension(R.dimen.andes_textfield_prefix_right_margin).toInt(), contentInterface.rightMargin(context))
         assertThat(contentInterface.component(context)).isEqualToComparingOnlyGivenFields(prefix)
     }
@@ -90,7 +90,7 @@ class AndesTextfieldContentInterfaceTest {
                 color = R.color.andes_gray_800.toAndesColor()))
 
         assertEquals(context.resources.getDimension(R.dimen.andes_textfield_icon_left_margin).toInt(), contentInterface.rightMargin(context))
-        assertEquals(context.resources.getDimension(R.dimen.andes_textfield_icon_right_margin).toInt(), contentInterface.leftMargin(context, AndesTextfieldState.IDLE))
+        assertEquals(context.resources.getDimension(R.dimen.andes_textfield_icon_right_margin).toInt(), contentInterface.leftMargin(context, AndesTextfieldState.IDLE.state))
         assertThat(contentInterface.component(context)).isEqualToComparingOnlyGivenFields(icon)
     }
 
@@ -105,7 +105,7 @@ class AndesTextfieldContentInterfaceTest {
         )
 
         assertEquals(context.resources.getDimension(R.dimen.andes_textfield_validated_left_margin).toInt(), contentInterface.rightMargin(context))
-        assertEquals(context.resources.getDimension(R.dimen.andes_textfield_validated_right_margin).toInt(), contentInterface.leftMargin(context, AndesTextfieldState.IDLE))
+        assertEquals(context.resources.getDimension(R.dimen.andes_textfield_validated_right_margin).toInt(), contentInterface.leftMargin(context, AndesTextfieldState.IDLE.state))
         assertThat(contentInterface.component(context)).isEqualToComparingOnlyGivenFields(validated)
     }
 
@@ -120,7 +120,7 @@ class AndesTextfieldContentInterfaceTest {
         )
 
         assertEquals(context.resources.getDimension(R.dimen.andes_textfield_clear_left_margin).toInt(), contentInterface.rightMargin(context))
-        assertEquals(context.resources.getDimension(R.dimen.andes_textfield_clear_right_margin).toInt(), contentInterface.leftMargin(context, AndesTextfieldState.IDLE))
+        assertEquals(context.resources.getDimension(R.dimen.andes_textfield_clear_right_margin).toInt(), contentInterface.leftMargin(context, AndesTextfieldState.IDLE.state))
         assertThat(contentInterface.component(context)).isEqualToComparingOnlyGivenFields(clear)
     }
 
@@ -130,7 +130,7 @@ class AndesTextfieldContentInterfaceTest {
         val action = AndesButton(context, AndesButtonSize.MEDIUM, AndesButtonHierarchy.TRANSPARENT)
 
         assertEquals(context.resources.getDimension(R.dimen.andes_textfield_action_left_margin).toInt(), contentInterface.rightMargin(context))
-        assertEquals(context.resources.getDimension(R.dimen.andes_textfield_action_right_margin).toInt(), contentInterface.leftMargin(context, AndesTextfieldState.IDLE))
+        assertEquals(context.resources.getDimension(R.dimen.andes_textfield_action_right_margin).toInt(), contentInterface.leftMargin(context, AndesTextfieldState.IDLE.state))
         assertThat(contentInterface.component(context)).isEqualToComparingOnlyGivenFields(action)
     }
 }

--- a/components/src/test/java/com/mercadolibre/android/andesui/textfield/AndesTexfieldContentInterfaceTest.kt
+++ b/components/src/test/java/com/mercadolibre/android/andesui/textfield/AndesTexfieldContentInterfaceTest.kt
@@ -19,6 +19,7 @@ import com.mercadolibre.android.andesui.color.toAndesColor
 import com.mercadolibre.android.andesui.color.toColor
 import com.mercadolibre.android.andesui.icons.IconProvider
 import com.mercadolibre.android.andesui.textfield.content.*
+import com.mercadolibre.android.andesui.textfield.state.AndesTextfieldState
 import com.mercadolibre.android.andesui.utils.buildColoredBitmapDrawable
 import junit.framework.Assert.assertEquals
 import org.assertj.core.api.Assertions.assertThat
@@ -62,7 +63,7 @@ class AndesTextfieldContentInterfaceTest {
         suffix.setTextColor(R.color.andes_gray_450.toColor(context))
         suffix.text = context.getString(R.string.andes_suffix_hint)
 
-        assertEquals(context.resources.getDimension(R.dimen.andes_textfield_suffix_left_margin).toInt(), contentInterface.leftMargin(context))
+        assertEquals(context.resources.getDimension(R.dimen.andes_textfield_suffix_left_margin).toInt(), contentInterface.leftMargin(context, AndesTextfieldState.IDLE))
         assertEquals(context.resources.getDimension(R.dimen.andes_textfield_suffix_right_margin).toInt(), contentInterface.rightMargin(context))
         assertThat(contentInterface.component(context)).isEqualToComparingOnlyGivenFields(suffix)
     }
@@ -74,7 +75,7 @@ class AndesTextfieldContentInterfaceTest {
         prefix.setTextColor(R.color.andes_gray_450.toColor(context))
         prefix.text = context.getString(R.string.andes_prefix_hint)
 
-        assertEquals(context.resources.getDimension(R.dimen.andes_textfield_prefix_left_margin).toInt(), contentInterface.leftMargin(context))
+        assertEquals(context.resources.getDimension(R.dimen.andes_textfield_prefix_left_margin).toInt(), contentInterface.leftMargin(context, AndesTextfieldState.IDLE))
         assertEquals(context.resources.getDimension(R.dimen.andes_textfield_prefix_right_margin).toInt(), contentInterface.rightMargin(context))
         assertThat(contentInterface.component(context)).isEqualToComparingOnlyGivenFields(prefix)
     }
@@ -89,7 +90,7 @@ class AndesTextfieldContentInterfaceTest {
                 color = R.color.andes_gray_800.toAndesColor()))
 
         assertEquals(context.resources.getDimension(R.dimen.andes_textfield_icon_left_margin).toInt(), contentInterface.rightMargin(context))
-        assertEquals(context.resources.getDimension(R.dimen.andes_textfield_icon_right_margin).toInt(), contentInterface.leftMargin(context))
+        assertEquals(context.resources.getDimension(R.dimen.andes_textfield_icon_right_margin).toInt(), contentInterface.leftMargin(context, AndesTextfieldState.IDLE))
         assertThat(contentInterface.component(context)).isEqualToComparingOnlyGivenFields(icon)
     }
 
@@ -104,7 +105,7 @@ class AndesTextfieldContentInterfaceTest {
         )
 
         assertEquals(context.resources.getDimension(R.dimen.andes_textfield_validated_left_margin).toInt(), contentInterface.rightMargin(context))
-        assertEquals(context.resources.getDimension(R.dimen.andes_textfield_validated_right_margin).toInt(), contentInterface.leftMargin(context))
+        assertEquals(context.resources.getDimension(R.dimen.andes_textfield_validated_right_margin).toInt(), contentInterface.leftMargin(context, AndesTextfieldState.IDLE))
         assertThat(contentInterface.component(context)).isEqualToComparingOnlyGivenFields(validated)
     }
 
@@ -119,7 +120,7 @@ class AndesTextfieldContentInterfaceTest {
         )
 
         assertEquals(context.resources.getDimension(R.dimen.andes_textfield_clear_left_margin).toInt(), contentInterface.rightMargin(context))
-        assertEquals(context.resources.getDimension(R.dimen.andes_textfield_clear_right_margin).toInt(), contentInterface.leftMargin(context))
+        assertEquals(context.resources.getDimension(R.dimen.andes_textfield_clear_right_margin).toInt(), contentInterface.leftMargin(context, AndesTextfieldState.IDLE))
         assertThat(contentInterface.component(context)).isEqualToComparingOnlyGivenFields(clear)
     }
 
@@ -129,7 +130,7 @@ class AndesTextfieldContentInterfaceTest {
         val action = AndesButton(context, AndesButtonSize.MEDIUM, AndesButtonHierarchy.TRANSPARENT)
 
         assertEquals(context.resources.getDimension(R.dimen.andes_textfield_action_left_margin).toInt(), contentInterface.rightMargin(context))
-        assertEquals(context.resources.getDimension(R.dimen.andes_textfield_action_right_margin).toInt(), contentInterface.leftMargin(context))
+        assertEquals(context.resources.getDimension(R.dimen.andes_textfield_action_right_margin).toInt(), contentInterface.leftMargin(context, AndesTextfieldState.IDLE))
         assertThat(contentInterface.component(context)).isEqualToComparingOnlyGivenFields(action)
     }
 }

--- a/demoapp/src/main/java/com/mercadolibre/android/andesui/demoapp/feature/TextfieldShowcaseActivity.kt
+++ b/demoapp/src/main/java/com/mercadolibre/android/andesui/demoapp/feature/TextfieldShowcaseActivity.kt
@@ -9,10 +9,7 @@ import android.text.InputType
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
-import android.widget.ArrayAdapter
-import android.widget.EditText
-import android.widget.ScrollView
-import android.widget.Spinner
+import android.widget.*
 import com.mercadolibre.android.andesui.button.AndesButton
 import com.mercadolibre.android.andesui.demoapp.PageIndicator
 import com.mercadolibre.android.andesui.demoapp.R
@@ -70,7 +67,7 @@ class TextfieldShowcaseActivity : AppCompatActivity() {
         }
 
         private fun addDynamicTextfieldLayout(inflater: LayoutInflater): View {
-            val layoutTextfield = inflater.inflate(R.layout.andesui_textfield_showcase_change, null, false) as ScrollView
+            val layoutTextfield = inflater.inflate(R.layout.andesui_textfield_showcase_change, null, false)
             val textfield = layoutTextfield.findViewById<AndesTextfield>(R.id.andesui_textfield)
             val button = layoutTextfield.findViewById<AndesButton>(R.id.change_button)
             val clearButton = layoutTextfield.findViewById<AndesButton>(R.id.clear_button)
@@ -78,44 +75,30 @@ class TextfieldShowcaseActivity : AppCompatActivity() {
             val helper = layoutTextfield.findViewById<EditText>(R.id.helper_text)
             val placeholder = layoutTextfield.findViewById<EditText>(R.id.placeholder_text)
             val counter = layoutTextfield.findViewById<EditText>(R.id.counter)
+            counter.setText(COUNTER_DEFAULT)
+            textfield.counter = 50
 
             val inputTypeSpinner: Spinner = layoutTextfield.findViewById(R.id.textType_spinner)
-            val adapter = ArrayAdapter(context, android.R.layout.simple_spinner_item, getInputTypesArray())
-            adapter.setDropDownViewResource(android.R.layout.simple_spinner_dropdown_item)
-            inputTypeSpinner.adapter = adapter
+            val typeAdapter = ArrayAdapter(context, android.R.layout.simple_spinner_item, getInputTypesArray())
+            typeAdapter.setDropDownViewResource(android.R.layout.simple_spinner_dropdown_item)
+            inputTypeSpinner.adapter = typeAdapter
 
             val stateSpinner: Spinner = layoutTextfield.findViewById(R.id.state_spinner)
-            ArrayAdapter.createFromResource(
-                    context,
-                    R.array.textfield_state_spinner,
-                    android.R.layout.simple_spinner_item
-            ).also { adapter ->
-                adapter.setDropDownViewResource(android.R.layout.simple_spinner_dropdown_item)
-                stateSpinner.adapter = adapter
-            }
+            val stateAdapter = ArrayAdapter(context, android.R.layout.simple_spinner_item, context.resources.getStringArray(R.array.textfield_state_spinner))
+            stateAdapter.setDropDownViewResource(android.R.layout.simple_spinner_dropdown_item)
+            stateSpinner.adapter = stateAdapter
 
             val preffixSpinner: Spinner = layoutTextfield.findViewById(R.id.prefix_spinner)
-            ArrayAdapter.createFromResource(
-                    context,
-                    R.array.prefix_spinner,
-                    android.R.layout.simple_spinner_item
-            ).also { adapter ->
-                adapter.setDropDownViewResource(android.R.layout.simple_spinner_dropdown_item)
-                preffixSpinner.adapter = adapter
-            }
+            val preffixAdapter = ArrayAdapter(context, android.R.layout.simple_spinner_item, context.resources.getStringArray(R.array.prefix_spinner))
+            preffixAdapter.setDropDownViewResource(android.R.layout.simple_spinner_dropdown_item)
+            preffixSpinner.adapter = preffixAdapter
 
             val suffixSpinner: Spinner = layoutTextfield.findViewById(R.id.suffix_spinner)
-            ArrayAdapter.createFromResource(
-                    context,
-                    R.array.suffix_spinner,
-                    android.R.layout.simple_spinner_item
-            ).also { adapter ->
-                adapter.setDropDownViewResource(android.R.layout.simple_spinner_dropdown_item)
-                suffixSpinner.adapter = adapter
-            }
+            val suffixAdapter = ArrayAdapter(context, android.R.layout.simple_spinner_item, context.resources.getStringArray(R.array.suffix_spinner))
+            suffixAdapter.setDropDownViewResource(android.R.layout.simple_spinner_dropdown_item)
+            suffixSpinner.adapter = suffixAdapter
 
             button.setOnClickListener {
-
                 textfield.text = ""
                 textfield.label = label.text.toString()
                 textfield.helper = helper.text.toString()
@@ -125,9 +108,23 @@ class TextfieldShowcaseActivity : AppCompatActivity() {
 
                 textfield.state = AndesTextfieldState.valueOf(stateSpinner.selectedItem.toString().toUpperCase())
 
-                textfield.leftContent = AndesTextfieldLeftContent.fromString(preffixSpinner.selectedItem.toString())
+                if (preffixSpinner.selectedItem.toString().toUpperCase() == NONE) {
+                    textfield.leftContent = null
+                } else {
+                    textfield.leftContent = AndesTextfieldLeftContent.fromString(preffixSpinner.selectedItem.toString())
 
-                textfield.rightContent = AndesTextfieldRightContent.fromString(suffixSpinner.selectedItem.toString())
+                }
+
+                if (suffixSpinner.selectedItem.toString().toUpperCase() == NONE) {
+                    textfield.rightContent = null
+                } else {
+                    textfield.rightContent = AndesTextfieldRightContent.fromString(suffixSpinner.selectedItem.toString())
+                    if (textfield.rightContent == AndesTextfieldRightContent.ACTION) {
+                        textfield.setAction("Button", View.OnClickListener {
+                            Toast.makeText(context, "Right action pressed", Toast.LENGTH_LONG).show()
+                        })
+                    }
+                }
 
                 val selectedInputType = getInputTypesArray().filter { it.name == inputTypeSpinner.selectedItem.toString() }.single().value
                 textfield.inputType = selectedInputType
@@ -135,24 +132,26 @@ class TextfieldShowcaseActivity : AppCompatActivity() {
 
             clearButton.setOnClickListener {
                 // reset UI
-                label.setText(null)
-                placeholder.setHint(context.resources.getString(R.string.andes_textfield_placeholder_text))
-                placeholder.setText(null)
+                label.text = null
+                placeholder.hint = context.resources.getString(R.string.andes_textfield_placeholder_text)
+                placeholder.text = null
+                helper.text = null
+                counter.setText(COUNTER_DEFAULT)
                 stateSpinner.setSelection(0)
-                helper.setText(null)
-                counter.setText(null)
-                inputTypeSpinner.setSelection(getInputTypesArray().filter { it.name == "text" }.single().value)
+                inputTypeSpinner.setSelection(0)
+                preffixSpinner.setSelection(0)
+                suffixSpinner.setSelection(0)
 
                 // reset AndesTextfield's properties.
                 textfield.text = ""
                 textfield.label = null
-                textfield.helper = null
                 textfield.placeholder = null
-                textfield.counter = 0
+                textfield.helper = null
+                textfield.counter = 50
                 textfield.state = AndesTextfieldState.IDLE
+                textfield.inputType = InputType.TYPE_CLASS_DATETIME
                 textfield.leftContent = null
                 textfield.rightContent = null
-                textfield.inputType = InputType.TYPE_CLASS_TEXT
             }
 
             return layoutTextfield
@@ -211,5 +210,10 @@ class TextfieldShowcaseActivity : AppCompatActivity() {
                 return this.name
             }
         }
+    }
+
+    companion object {
+        const val NONE = "NONE"
+        const val COUNTER_DEFAULT = "50"
     }
 }

--- a/demoapp/src/main/java/com/mercadolibre/android/andesui/demoapp/feature/TextfieldShowcaseActivity.kt
+++ b/demoapp/src/main/java/com/mercadolibre/android/andesui/demoapp/feature/TextfieldShowcaseActivity.kt
@@ -112,7 +112,6 @@ class TextfieldShowcaseActivity : AppCompatActivity() {
                     textfield.leftContent = null
                 } else {
                     textfield.leftContent = AndesTextfieldLeftContent.fromString(preffixSpinner.selectedItem.toString())
-
                 }
 
                 if (suffixSpinner.selectedItem.toString().toUpperCase() == NONE) {

--- a/demoapp/src/main/res/layout/andesui_textfield_showcase_change.xml
+++ b/demoapp/src/main/res/layout/andesui_textfield_showcase_change.xml
@@ -1,140 +1,202 @@
 <?xml version="1.0" encoding="utf-8"?>
 <ScrollView xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
     android:layout_width="match_parent"
-    android:layout_height="match_parent"
-    xmlns:app="http://schemas.android.com/apk/res-auto">
+    android:layout_height="match_parent">
 
-    <LinearLayout
+    <android.support.constraint.ConstraintLayout
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
-        android:animateLayoutChanges="true"
-        android:orientation="vertical"
-        android:padding="@dimen/button_margin_vertical">
+        android:isScrollContainer="true">
 
         <com.mercadolibre.android.andesui.textfield.AndesTextfield
             android:id="@+id/andesui_textfield"
-            android:layout_width="match_parent"
+            android:layout_width="0dp"
             android:layout_height="wrap_content"
+            android:layout_marginStart="@dimen/margin_vertical_text_field"
+            android:layout_marginTop="@dimen/margin_vertical_text_field"
+            android:layout_marginEnd="@dimen/margin_vertical_text_field"
             app:andesTextfieldState="idle"
-            android:layout_marginBottom="@dimen/button_margin_vertical"
-            android:inputType="text"
-            />
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toTopOf="parent" />
 
         <TextView
+            android:id="@+id/textView"
+            android:layout_width="0dp"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="24dp"
             android:text="@string/andesui_demoapp_textfield_input_type"
             android:textColor="@color/andes_gray_800"
-            android:layout_width="match_parent"
-            android:layout_height="wrap_content" />
+            app:layout_constraintEnd_toStartOf="@+id/textType_spinner"
+            app:layout_constraintHorizontal_bias="0.5"
+            app:layout_constraintHorizontal_chainStyle="spread_inside"
+            app:layout_constraintStart_toStartOf="@+id/andesui_textfield"
+            app:layout_constraintTop_toBottomOf="@+id/andesui_textfield" />
 
         <Spinner
             android:id="@+id/textType_spinner"
-            android:layout_width="match_parent"
+            android:layout_width="0dp"
             android:layout_height="wrap_content"
-            android:layout_marginTop="10dp" />
+            app:layout_constraintBottom_toBottomOf="@+id/textView"
+            app:layout_constraintEnd_toEndOf="@+id/andesui_textfield"
+            app:layout_constraintHorizontal_bias="0.5"
+            app:layout_constraintStart_toEndOf="@+id/textView"
+            app:layout_constraintTop_toTopOf="@+id/textView" />
 
         <TextView
+            android:id="@+id/textView2"
+            android:layout_width="0dp"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="@dimen/margin_vertical_text_field"
             android:text="@string/andesui_demoapp_textfield_state_text"
             android:textColor="@color/andes_gray_800"
-            android:layout_width="match_parent"
-            android:layout_height="wrap_content" />
+            app:layout_constraintEnd_toStartOf="@+id/state_spinner"
+            app:layout_constraintHorizontal_bias="0.5"
+            app:layout_constraintHorizontal_chainStyle="spread_inside"
+            app:layout_constraintStart_toStartOf="@+id/textView"
+            app:layout_constraintTop_toBottomOf="@+id/textView" />
 
         <Spinner
             android:id="@+id/state_spinner"
-            android:layout_width="match_parent"
+            android:layout_width="0dp"
             android:layout_height="wrap_content"
-            android:layout_marginTop="10dp" />
+            app:layout_constraintBottom_toBottomOf="@+id/textView2"
+            app:layout_constraintEnd_toEndOf="@+id/textType_spinner"
+            app:layout_constraintHorizontal_bias="0.5"
+            app:layout_constraintStart_toEndOf="@+id/textView2"
+            app:layout_constraintTop_toTopOf="@+id/textView2" />
 
         <TextView
+            android:id="@+id/textView3"
+            android:layout_width="0dp"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="@dimen/margin_vertical_text_field"
             android:text="@string/andesui_demoapp_textfield_prefix_text"
             android:textColor="@color/andes_gray_800"
-            android:layout_width="match_parent"
-            android:layout_height="wrap_content"
-            android:layout_marginTop="@dimen/andes_textfield_container_marginTop"/>
+            app:layout_constraintEnd_toStartOf="@+id/prefix_spinner"
+            app:layout_constraintHorizontal_bias="0.5"
+            app:layout_constraintHorizontal_chainStyle="spread_inside"
+            app:layout_constraintStart_toStartOf="@+id/textView2"
+            app:layout_constraintTop_toBottomOf="@+id/textView2" />
 
         <Spinner
             android:id="@+id/prefix_spinner"
-            android:layout_width="match_parent"
+            android:layout_width="0dp"
             android:layout_height="wrap_content"
-            android:layout_marginTop="10dp" />
+            app:layout_constraintBottom_toBottomOf="@+id/textView3"
+            app:layout_constraintEnd_toEndOf="@+id/state_spinner"
+            app:layout_constraintHorizontal_bias="0.5"
+            app:layout_constraintStart_toEndOf="@+id/textView3"
+            app:layout_constraintTop_toTopOf="@+id/textView3" />
 
         <TextView
+            android:id="@+id/textView4"
+            android:layout_width="0dp"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="@dimen/margin_vertical_text_field"
             android:text="@string/andesui_demoapp_textfield_suffix_text"
             android:textColor="@color/andes_gray_800"
-            android:layout_width="match_parent"
-            android:layout_height="wrap_content"
-            android:layout_marginTop="@dimen/andes_textfield_container_marginTop"/>
+            app:layout_constraintEnd_toStartOf="@+id/suffix_spinner"
+            app:layout_constraintHorizontal_bias="0.5"
+            app:layout_constraintHorizontal_chainStyle="spread_inside"
+            app:layout_constraintStart_toStartOf="@+id/textView3"
+            app:layout_constraintTop_toBottomOf="@+id/textView3" />
 
         <Spinner
             android:id="@+id/suffix_spinner"
-            android:layout_width="match_parent"
+            android:layout_width="0dp"
             android:layout_height="wrap_content"
-            android:layout_marginTop="10dp" />
+            app:layout_constraintBottom_toBottomOf="@+id/textView4"
+            app:layout_constraintEnd_toEndOf="@+id/prefix_spinner"
+            app:layout_constraintHorizontal_bias="0.5"
+            app:layout_constraintStart_toEndOf="@+id/textView4"
+            app:layout_constraintTop_toTopOf="@+id/textView4" />
 
         <EditText
             android:id="@+id/label_text"
-            android:layout_width="match_parent"
+            android:layout_width="0dp"
             android:layout_height="wrap_content"
+            android:layout_marginTop="@dimen/margin_vertical_text_field"
             android:hint="@string/andes_textfield_label_text"
-            android:inputType="text"
-            android:layout_marginTop="@dimen/andes_textfield_container_marginTop"/>
+            android:inputType="textCapWords|textCapSentences"
+            app:layout_constraintEnd_toEndOf="@+id/suffix_spinner"
+            app:layout_constraintStart_toStartOf="@+id/textView4"
+            app:layout_constraintTop_toBottomOf="@+id/textView4" />
 
         <EditText
             android:id="@+id/placeholder_text"
-            android:layout_width="match_parent"
+            android:layout_width="0dp"
             android:layout_height="wrap_content"
+            android:layout_marginTop="@dimen/margin_vertical_text_field"
             android:hint="@string/andes_textfield_placeholder_text"
-            android:inputType="text" />
+            android:inputType="textCapWords|textCapSentences"
+            app:layout_constraintEnd_toEndOf="@+id/label_text"
+            app:layout_constraintStart_toStartOf="@+id/label_text"
+            app:layout_constraintTop_toBottomOf="@+id/label_text" />
 
         <EditText
             android:id="@+id/helper_text"
-            android:layout_width="match_parent"
+            android:layout_width="0dp"
             android:layout_height="wrap_content"
+            android:layout_marginTop="@dimen/margin_vertical_text_field"
             android:hint="@string/andes_textfield_helper_text"
-            android:inputType="text" />
+            android:inputType="textCapWords|textCapSentences"
+            app:layout_constraintEnd_toEndOf="@+id/placeholder_text"
+            app:layout_constraintStart_toStartOf="@+id/placeholder_text"
+            app:layout_constraintTop_toBottomOf="@+id/placeholder_text" />
 
-        <android.support.v7.widget.LinearLayoutCompat
-            android:layout_width="match_parent"
+        <TextView
+            android:id="@+id/textView5"
+            android:layout_width="wrap_content"
             android:layout_height="wrap_content"
-            android:orientation="horizontal">
+            android:layout_marginTop="24dp"
+            android:text="@string/andesui_demoapp_counter_text"
+            android:textColor="@color/andes_gray_800"
+            app:layout_constraintStart_toStartOf="@+id/helper_text"
+            app:layout_constraintTop_toBottomOf="@+id/helper_text" />
 
-            <TextView
-                android:text="@string/andesui_demoapp_counter_text"
-                android:textColor="@color/andes_gray_800"
-                android:layout_width="wrap_content"
-                android:layout_height="wrap_content" />
+        <EditText
+            android:id="@+id/counter"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_marginStart="@dimen/margin_horizontal_text_field"
+            android:inputType="number"
+            app:layout_constraintBottom_toBottomOf="@+id/textView5"
+            app:layout_constraintStart_toEndOf="@+id/textView5"
+            app:layout_constraintTop_toTopOf="@+id/textView5" />
 
-            <EditText
-                android:id="@+id/counter"
-                android:inputType="number"
-                android:layout_width="wrap_content"
-                android:layout_height="wrap_content"/>
+        <com.mercadolibre.android.andesui.button.AndesButton
+            android:id="@+id/change_button"
+            android:layout_width="0dp"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="24dp"
+            android:layout_marginEnd="@dimen/margin_vertical_text_field"
+            android:layout_marginBottom="24dp"
+            app:andesButtonHierarchy="loud"
+            app:andesButtonSize="large"
+            app:andesButtonText="@string/andes_message_showcase_change"
+            app:layout_constraintBottom_toBottomOf="parent"
+            app:layout_constraintEnd_toStartOf="@+id/clear_button"
+            app:layout_constraintHorizontal_bias="0.5"
+            app:layout_constraintStart_toStartOf="@+id/textView5"
+            app:layout_constraintTop_toBottomOf="@+id/textView5" />
 
-        </android.support.v7.widget.LinearLayoutCompat>
+        <com.mercadolibre.android.andesui.button.AndesButton
+            android:id="@+id/clear_button"
+            android:layout_width="@dimen/button_clear_width"
+            android:layout_height="wrap_content"
+            app:andesButtonHierarchy="loud"
+            app:andesButtonSize="large"
+            app:andesButtonText="@string/andesui_demoapp_clear_button"
+            app:layout_constraintBottom_toBottomOf="@+id/change_button"
+            app:layout_constraintEnd_toEndOf="@+id/helper_text"
+            app:layout_constraintHorizontal_bias="0.5"
+            app:layout_constraintStart_toEndOf="@+id/change_button"
+            app:layout_constraintTop_toTopOf="@+id/change_button" />
 
-        <LinearLayout
-            android:orientation="horizontal"
-            android:layout_width="match_parent"
-            android:layout_height="wrap_content">
+    </android.support.constraint.ConstraintLayout>
 
-            <com.mercadolibre.android.andesui.button.AndesButton
-                android:id="@+id/change_button"
-                android:layout_width="wrap_content"
-                android:layout_height="wrap_content"
-                app:andesButtonHierarchy="loud"
-                app:andesButtonSize="large"
-                app:andesButtonText="@string/andes_message_showcase_change"
-                android:layout_marginRight="@dimen/andes_textfield_edittext_paddingRight"
-                android:layout_marginTop="@dimen/andes_textfield_container_marginTop"/>
-
-            <com.mercadolibre.android.andesui.button.AndesButton
-                android:id="@+id/clear_button"
-                android:layout_width="wrap_content"
-                android:layout_height="wrap_content"
-                app:andesButtonHierarchy="loud"
-                app:andesButtonSize="large"
-                app:andesButtonText="@string/andesui_demoapp_clear_button"
-                android:layout_marginTop="@dimen/andes_textfield_container_marginTop"/>
-        </LinearLayout>
-
-    </LinearLayout>
 </ScrollView>
+
+

--- a/demoapp/src/main/res/raw/andesui_demoapp_changelog.md
+++ b/demoapp/src/main/res/raw/andesui_demoapp_changelog.md
@@ -1,10 +1,11 @@
 # v2.3.0
 ## Changed
 - Minor UX improvements in the Andes App.
+- Minor errors in textfield.
 
 # v2.2.0
 ## Changed
-- Remove modifier from AndesBadge
+- Remove modifier from AndesBadge.
 
 ## Fixed
 - Label error textfield color.

--- a/demoapp/src/main/res/values/dimens.xml
+++ b/demoapp/src/main/res/values/dimens.xml
@@ -4,4 +4,8 @@
     <dimen name="button_margin_vertical">16dp</dimen>
     <dimen name="button_margin_vertical_2x">32dp</dimen>
     <dimen name="badge_margin_vertical">4dp</dimen>
+
+    <dimen name="margin_vertical_text_field">16dp</dimen>
+    <dimen name="margin_horizontal_text_field">16dp</dimen>
+    <dimen name="button_clear_width">120dp</dimen>
 </resources>

--- a/demoapp/src/main/res/values/strings.xml
+++ b/demoapp/src/main/res/values/strings.xml
@@ -68,8 +68,8 @@
     <string name="andesui_demoapp_clear_button">Clear</string>
     <string name="andesui_demoapp_textfiled">Andes Textfield</string>
     <string name="andesui_demoapp_textfield_state_text">State:</string>
-    <string name="andesui_demoapp_textfield_prefix_text">Prefix:</string>
-    <string name="andesui_demoapp_textfield_suffix_text">Suffix:</string>
+    <string name="andesui_demoapp_textfield_prefix_text">Left component:</string>
+    <string name="andesui_demoapp_textfield_suffix_text">Right component:</string>
     <string name="andesui_demoapp_counter_text">Counter:</string>
     <string name="andesui_demoapp_counter_separator">/</string>
     <string name="andesui_demoapp_textfield_input_type">Input Type:</string>
@@ -96,22 +96,24 @@
 
     <string-array name="textfield_state_spinner">
         <item>Idle</item>
-        <item>Disabled</item>
         <item>Error</item>
+        <item>Disabled</item>
         <item>Readonly</item>
     </string-array>
 
     <string-array name="suffix_spinner">
-        <item>Suffix</item>
-        <item>Icon</item>
-        <item>Validated</item>
-        <item>Clear</item>
+        <item>None</item>
         <item>Action</item>
+        <item>Clear</item>
+        <item>Icon</item>
+        <item>Suffix</item>
+        <item>Validated</item>
     </string-array>
 
     <string-array name="prefix_spinner">
-        <item>Prefix</item>
+        <item>None</item>
         <item>Icon</item>
+        <item>Prefix</item>
     </string-array>
 
 </resources>


### PR DESCRIPTION
### Thanks for starting a pull request on Andes UI!

## Description
Fixes en textfield y cambios mínimos en la testapp.

**Fixes en textfield**
- El helper y el counter se veía con el state "read-only"
- El padding izquierdo del textfield está mal con el state "read-only" (desalineado al label)
- En "disabled" y "read-only" el action no se pone en disabled.
- Error con el helper.

**Se cambio**
- Se agregó toast con el callback de "action"
- Se agregó la opción "None" para el "Prefix" y "Sufix".
- Cambió el nombre de "Prefix" y "Sufix" a "Left content" y "Right content" respectivamente.
- En la testapp, el counter se puso por defecto en 50.

## Checks
Are you sure you followed all those steps? In such case, let's say with me "I solemnly declare that ...":
- [ ] I have coded an example inside the Demo App,
- [ ] I have added proper tests,
- [x] I have modified the [Changelog](https://github.com/mercadolibre/fury_andesui-android/blob/develop/CHANGELOG.md) file,
- [ ] I have updated GitHub wiki,
- [ ] I have the explicit approval of one or more members of the UX Team,
- [ ] I have updated the version in gradle.properties file.

## Change type
This is easy, let us know what this code is about:
- [ ] This code adds a new component
- [x] This code includes improvements to an existent component
- [ ] This code improves or modifies ONLY the Demo App.

## Check common errors
Whether you are an Android or iOS developer and if you're still there then we'll give you a present:
https://proandroiddev.com/how-to-maximize-androids-ui-reusability-5-common-mistakes-cb2571216a9f
