### PR TITLE
Fix AndesBadgePill error

### DIFF
--- a/components/src/main/java/com/mercadolibre/android/andesui/badge/AndesBadgePill.kt
+++ b/components/src/main/java/com/mercadolibre/android/andesui/badge/AndesBadgePill.kt
@@ -8,7 +8,7 @@ import android.util.TypedValue
 import android.view.Gravity
 import android.view.LayoutInflater
 import android.view.View
-import android.view.ViewGroup
+import android.widget.LinearLayout
 import android.widget.TextView
 import com.mercadolibre.android.andesui.R
 import com.mercadolibre.android.andesui.badge.border.AndesBadgePillBorder
@@ -186,7 +186,7 @@ class AndesBadgePill : CardView {
                 shape.setColor(config.backgroundColor.colorInt(context))
 
                 background = shape
-                layoutParams = ViewGroup.LayoutParams(LayoutParams.WRAP_CONTENT, config.height.toInt())
+                layoutParams = LinearLayout.LayoutParams(LayoutParams.WRAP_CONTENT, config.height.toInt())
                 minimumWidth = config.height.toInt()
                 minimumHeight = config.height.toInt()
     }


### PR DESCRIPTION
### Thanks for starting a pull request on Andes UI!

## Description
La AndesBadgePill provocaba un crash de la App cuando se cambiaba programaticamente Type, Hierarchy o Size, porque la altura se cambiaba con un ViewGroup.LayoutParam mientras que se espera un LinearLayout.LayoutParam.

## Affected component
AndesBadgePill

## Frontify component link
[AndesBadge Frontify](https://company-161429.frontify.com/d/kxHCRixezmfK/n-a#/componentes/badge)

## Screenshots
This is a UI library, delight us with some stunning images.


## Checks
Are you sure you followed all those steps? In such case, let's say with me "I solemnly declare that ...":
- [ ] I have coded an example inside the Demo App,
- [ ] I have added proper tests,
- [ ] I have modified the [Changelog](https://github.com/mercadolibre/fury_andesui-android/blob/develop/CHANGELOG.md) file,
- [ ] I have updated GitHub wiki,
- [ ] I have the explicit approval of one or more members of the UX Team,
- [ ] I have updated the version in gradle.properties file.

## Change type
This is easy, let us know what this code is about:
- [ ] This code adds a new component
- [x] This code includes improvements to an existent component
- [ ] This code improves or modifies ONLY the Demo App.

## Check common errors
Whether you are an Android or iOS developer and if you're still there then we'll give you a present:
https://proandroiddev.com/how-to-maximize-androids-ui-reusability-5-common-mistakes-cb2571216a9f
