### PR TITLE
Se depreca el soporte de las fuentes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,6 @@
 - Minor UX improvements in the Andes App.
 - Minor improvements in textfield.
 - Minor improvements in textarea.
-- Deprecate Font support.
 
 ## Fixed
 - The format property is added to the resources of the attrs.xml file, so that it can be compiled with AGP 3.6 and gradle 5 + androidx.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+# v2.3.1
+
+## Changed
+- Deprecate Font support.
+
 # v2.3.0
 ## Added
 - Badge Component DOT.
@@ -6,6 +11,7 @@
 - Minor UX improvements in the Andes App.
 - Minor improvements in textfield.
 - Minor improvements in textarea.
+- Deprecate Font support.
 
 ## Fixed
 - The format property is added to the resources of the attrs.xml file, so that it can be compiled with AGP 3.6 and gradle 5 + androidx.

--- a/components/src/main/java/com/mercadolibre/android/andesui/font/TextViewExtension.kt
+++ b/components/src/main/java/com/mercadolibre/android/andesui/font/TextViewExtension.kt
@@ -8,6 +8,7 @@ import android.widget.TextView
  * @param <T>   A generic for the textview
  * @param font The [Font] the text should have
  */
+@Deprecated("Font support will be removed")
 fun TextView.setTypeface(font: Font) {
     TypefaceHelper.setTypeface(this, font)
 }
@@ -17,6 +18,7 @@ fun TextView.setTypeface(font: Font) {
  * @param paint The paint to which apply the font
  * @param font The [Font] the text should have
  */
+@Deprecated("Font support will be removed")
 fun TextView.setTypeface(paint: Paint, font: Font) {
     TypefaceHelper.setTypeface(context, paint, font)
 }

--- a/components/src/main/java/com/mercadolibre/android/andesui/font/TextViewExtension.kt
+++ b/components/src/main/java/com/mercadolibre/android/andesui/font/TextViewExtension.kt
@@ -8,8 +8,7 @@ import android.widget.TextView
  * @param <T>   A generic for the textview
  * @param font The [Font] the text should have
  *
- * @Deprecated: instead you can use ResourceCompat
- * https://developer.android.com/reference/android/support/v4/content/res/ResourcesCompat#getfont.
+ * @deprecated: instead you can use ResourceCompat (https://developer.android.com/reference/android/support/v4/content/res/ResourcesCompat#getfont)
  */
 @Deprecated(message = "Font support will be removed, instead you can use ResourceCompat.getFont().")
 fun TextView.setTypeface(font: Font) {
@@ -21,8 +20,7 @@ fun TextView.setTypeface(font: Font) {
  * @param paint The paint to which apply the font
  * @param font The [Font] the text should have
 
- * @Deprecated: instead you can use ResourceCompat
- * https://developer.android.com/reference/android/support/v4/content/res/ResourcesCompat#getfont.
+ * @deprecated: instead you can use ResourceCompat (https://developer.android.com/reference/android/support/v4/content/res/ResourcesCompat#getfont)
  */
 @Deprecated(message = "Font support will be removed, instead you can use ResourceCompat.getFont().")
 fun TextView.setTypeface(paint: Paint, font: Font) {

--- a/components/src/main/java/com/mercadolibre/android/andesui/font/TextViewExtension.kt
+++ b/components/src/main/java/com/mercadolibre/android/andesui/font/TextViewExtension.kt
@@ -7,8 +7,11 @@ import android.widget.TextView
  * Sets the typeface to the given view
  * @param <T>   A generic for the textview
  * @param font The [Font] the text should have
+ *
+ * @Deprecated: instead you can use ResourceCompat
+ * https://developer.android.com/reference/android/support/v4/content/res/ResourcesCompat#getfont.
  */
-@Deprecated("Font support will be removed")
+@Deprecated(message = "Font support will be removed, instead you can use ResourceCompat.getFont().")
 fun TextView.setTypeface(font: Font) {
     TypefaceHelper.setTypeface(this, font)
 }
@@ -17,8 +20,11 @@ fun TextView.setTypeface(font: Font) {
  * Sets the typeface to the given [Paint]
  * @param paint The paint to which apply the font
  * @param font The [Font] the text should have
+
+ * @Deprecated: instead you can use ResourceCompat
+ * https://developer.android.com/reference/android/support/v4/content/res/ResourcesCompat#getfont.
  */
-@Deprecated("Font support will be removed")
+@Deprecated(message = "Font support will be removed, instead you can use ResourceCompat.getFont().")
 fun TextView.setTypeface(paint: Paint, font: Font) {
     TypefaceHelper.setTypeface(context, paint, font)
 }

--- a/components/src/main/java/com/mercadolibre/android/andesui/font/TypefaceHelper.kt
+++ b/components/src/main/java/com/mercadolibre/android/andesui/font/TypefaceHelper.kt
@@ -10,8 +10,7 @@ import android.widget.TextView
  * This class is used as a wrapper for our custom font.
  * If you code create a View that supports typeface you should call one of this methods.
  *
- * @Deprecated: instead you can use ResourceCompat
- * https://developer.android.com/reference/android/support/v4/content/res/ResourcesCompat#getfont.
+ * @deprecated: instead you can use ResourceCompat (https://developer.android.com/reference/android/support/v4/content/res/ResourcesCompat#getfont)
  */
 @Deprecated(message = "Font support will be removed, instead you can use ResourceCompat.getFont().")
 object TypefaceHelper {

--- a/components/src/main/java/com/mercadolibre/android/andesui/font/TypefaceHelper.kt
+++ b/components/src/main/java/com/mercadolibre/android/andesui/font/TypefaceHelper.kt
@@ -10,6 +10,7 @@ import android.widget.TextView
  * This class is used as a wrapper for our custom font.
  * If you code create a View that supports typeface you should call one of this methods.
  */
+@Deprecated("Font support will be removed")
 object TypefaceHelper {
 
     private lateinit var typefaceSetter: TypefaceSetter

--- a/components/src/main/java/com/mercadolibre/android/andesui/font/TypefaceHelper.kt
+++ b/components/src/main/java/com/mercadolibre/android/andesui/font/TypefaceHelper.kt
@@ -9,8 +9,11 @@ import android.widget.TextView
 /**
  * This class is used as a wrapper for our custom font.
  * If you code create a View that supports typeface you should call one of this methods.
+ *
+ * @Deprecated: instead you can use ResourceCompat
+ * https://developer.android.com/reference/android/support/v4/content/res/ResourcesCompat#getfont.
  */
-@Deprecated("Font support will be removed")
+@Deprecated(message = "Font support will be removed, instead you can use ResourceCompat.getFont().")
 object TypefaceHelper {
 
     private lateinit var typefaceSetter: TypefaceSetter

--- a/components/src/main/java/com/mercadolibre/android/andesui/font/TypefaceSpanCompat.kt
+++ b/components/src/main/java/com/mercadolibre/android/andesui/font/TypefaceSpanCompat.kt
@@ -9,8 +9,7 @@ import android.text.style.TypefaceSpan
  * This class replace the [CalligraphyTypefaceSpan](https://github.com/chrisjenx/Calligraphy/blob/master/calligraphy/src/main/java/uk/co/chrisjenx/calligraphy/CalligraphyTypefaceSpan.java) from [Calligraphy](https://github.com/chrisjenx/Calligraphy)
  * The motivation is to no depend on a library implementation
  *
- * @Deprecated: instead you can use ResourceCompat
- * https://developer.android.com/reference/android/support/v4/content/res/ResourcesCompat#getfont.
+ * @deprecated: instead you can use ResourceCompat (https://developer.android.com/reference/android/support/v4/content/res/ResourcesCompat#getfont)
  */
 @Deprecated(message = "Font support will be removed, instead you can use ResourceCompat.getFont().")
 class TypefaceSpanCompat

--- a/components/src/main/java/com/mercadolibre/android/andesui/font/TypefaceSpanCompat.kt
+++ b/components/src/main/java/com/mercadolibre/android/andesui/font/TypefaceSpanCompat.kt
@@ -8,8 +8,11 @@ import android.text.style.TypefaceSpan
 /**
  * This class replace the [CalligraphyTypefaceSpan](https://github.com/chrisjenx/Calligraphy/blob/master/calligraphy/src/main/java/uk/co/chrisjenx/calligraphy/CalligraphyTypefaceSpan.java) from [Calligraphy](https://github.com/chrisjenx/Calligraphy)
  * The motivation is to no depend on a library implementation
+ *
+ * @Deprecated: instead you can use ResourceCompat
+ * https://developer.android.com/reference/android/support/v4/content/res/ResourcesCompat#getfont.
  */
-@Deprecated("Font support will be removed")
+@Deprecated(message = "Font support will be removed, instead you can use ResourceCompat.getFont().")
 class TypefaceSpanCompat
 
     /**

--- a/components/src/main/java/com/mercadolibre/android/andesui/font/TypefaceSpanCompat.kt
+++ b/components/src/main/java/com/mercadolibre/android/andesui/font/TypefaceSpanCompat.kt
@@ -9,6 +9,7 @@ import android.text.style.TypefaceSpan
  * This class replace the [CalligraphyTypefaceSpan](https://github.com/chrisjenx/Calligraphy/blob/master/calligraphy/src/main/java/uk/co/chrisjenx/calligraphy/CalligraphyTypefaceSpan.java) from [Calligraphy](https://github.com/chrisjenx/Calligraphy)
  * The motivation is to no depend on a library implementation
  */
+@Deprecated("Font support will be removed")
 class TypefaceSpanCompat
 
     /**

--- a/components/src/main/java/com/mercadolibre/android/andesui/font/TypefaceSpanFactory.kt
+++ b/components/src/main/java/com/mercadolibre/android/andesui/font/TypefaceSpanFactory.kt
@@ -8,6 +8,7 @@ import android.text.style.TypefaceSpan
 /**
  * This class wrap the TypefaceSpan creation to split according to the Android API version
  */
+@Deprecated("Font support will be removed")
 object TypefaceSpanFactory {
 
     /**

--- a/components/src/main/java/com/mercadolibre/android/andesui/font/TypefaceSpanFactory.kt
+++ b/components/src/main/java/com/mercadolibre/android/andesui/font/TypefaceSpanFactory.kt
@@ -7,8 +7,11 @@ import android.text.style.TypefaceSpan
 
 /**
  * This class wrap the TypefaceSpan creation to split according to the Android API version
+ *
+ * @Deprecated: instead you can use ResourceCompat
+ * https://developer.android.com/reference/android/support/v4/content/res/ResourcesCompat#getfont.
  */
-@Deprecated("Font support will be removed")
+@Deprecated(message = "Font support will be removed, instead you can use ResourceCompat.getFont().")
 object TypefaceSpanFactory {
 
     /**

--- a/components/src/main/java/com/mercadolibre/android/andesui/font/TypefaceSpanFactory.kt
+++ b/components/src/main/java/com/mercadolibre/android/andesui/font/TypefaceSpanFactory.kt
@@ -8,8 +8,7 @@ import android.text.style.TypefaceSpan
 /**
  * This class wrap the TypefaceSpan creation to split according to the Android API version
  *
- * @Deprecated: instead you can use ResourceCompat
- * https://developer.android.com/reference/android/support/v4/content/res/ResourcesCompat#getfont.
+ * @deprecated: instead you can use ResourceCompat (https://developer.android.com/reference/android/support/v4/content/res/ResourcesCompat#getfont)
  */
 @Deprecated(message = "Font support will be removed, instead you can use ResourceCompat.getFont().")
 object TypefaceSpanFactory {

--- a/demoapp/src/main/res/raw/andesui_demoapp_changelog.md
+++ b/demoapp/src/main/res/raw/andesui_demoapp_changelog.md
@@ -1,3 +1,8 @@
+# v2.3.1
+
+## Changed
+- Deprecate Font support.
+
 # v2.3.0
 ## Added
 - Badge Component DOT.

--- a/gradle.properties
+++ b/gradle.properties
@@ -39,7 +39,7 @@ libraryGroupId=com.mercadolibre.android.andesui
 # IMPORTANT: We're using http://semver.org/ for all Android projects, please remember to follow this convention.
 # IMPORTANT: The version will be THE SAME for all modules.
 # For libraryVersion do NOT add a qualifier to this version like LOCAL/EXPERIMENTAL (it'll be added automatically!)
-libraryVersion=2.3.0
+libraryVersion=2.3.1
 
 ##################################################################################
 # Project setup


### PR DESCRIPTION
### Thanks for starting a pull request on Andes UI!

## Description
Se elimina el soporte de las fuentes. 
Se va a empezar a impulsar a los equipos a usar Andes (cada componente ya te resuelve la font)

## Checks
Are you sure you followed all those steps? In such case, let's say with me "I solemnly declare that ...":
- [ ] I have coded an example inside the Demo App,
- [ ] I have added proper tests,
- [X] I have modified the [Changelog](https://github.com/mercadolibre/fury_andesui-android/blob/develop/CHANGELOG.md) file,
- [ ] I have updated GitHub wiki,
- [ ] I have the explicit approval of one or more members of the UX Team,
- [X] I have updated the version in gradle.properties file.

## Change type
This is easy, let us know what this code is about:
- [ ] This code adds a new component
- [X] This code includes improvements to an existent component
- [ ] This code improves or modifies ONLY the Demo App.

## Check common errors
Whether you are an Android or iOS developer and if you're still there then we'll give you a present:
https://proandroiddev.com/how-to-maximize-androids-ui-reusability-5-common-mistakes-cb2571216a9f
