### PR TITLE
Add TextWatcher in Textfield

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# v2.5.1
+## Added
+- Add TextWatcher in TextField and TextArea
+
 # v2.5.0
 ## Added
 - TAG Component.

--- a/components/src/main/java/com/mercadolibre/android/andesui/textfield/AndesTextarea.kt
+++ b/components/src/main/java/com/mercadolibre/android/andesui/textfield/AndesTextarea.kt
@@ -95,7 +95,7 @@ class AndesTextarea : ConstraintLayout {
         }
 
     /**
-     * Getter and setter for the [rightContent].
+     * Getter and setter for the [textWatcher].
      */
     var textWatcher: TextWatcher?
         get() = andesTextareaAttrs.textWatcher

--- a/components/src/main/java/com/mercadolibre/android/andesui/textfield/AndesTextarea.kt
+++ b/components/src/main/java/com/mercadolibre/android/andesui/textfield/AndesTextarea.kt
@@ -227,8 +227,9 @@ class AndesTextarea : ConstraintLayout {
      * Set the TextWatcher of the edit text.
      */
     private fun setupTextWatcher() {
-        andesTextareaAttrs.textWatcher? 
+        if (andesTextareaAttrs.textWatcher != null) {
             textComponent.addTextChangedListener(andesTextareaAttrs.textWatcher)
+        }
     }
 
     /**

--- a/components/src/main/java/com/mercadolibre/android/andesui/textfield/AndesTextarea.kt
+++ b/components/src/main/java/com/mercadolibre/android/andesui/textfield/AndesTextarea.kt
@@ -94,6 +94,16 @@ class AndesTextarea : ConstraintLayout {
             setupMaxlines(createConfig())
         }
 
+    /**
+     * Getter and setter for the [rightContent].
+     */
+    var textWatcher: TextWatcher?
+        get() = andesTextareaAttrs.textWatcher
+        set(value) {
+            andesTextareaAttrs = andesTextareaAttrs.copy(textWatcher = value)
+            setupTextWatcher()
+        }
+
     private lateinit var andesTextareaAttrs: AndesTextareaAttrs
     private lateinit var textareaContainer: ConstraintLayout
     private lateinit var textContainer: ConstraintLayout
@@ -158,6 +168,7 @@ class AndesTextarea : ConstraintLayout {
         setupPlaceHolderComponent(config)
         setupColorComponents(config)
         setupMaxlines(config)
+        setupTextWatcher()
         setupTextComponent(config)
     }
 
@@ -210,6 +221,15 @@ class AndesTextarea : ConstraintLayout {
     private fun setupTextComponent(config: AndesTextfieldConfiguration) {
         setupMarginStartTextComponent()
         textComponent.typeface = config.typeface
+    }
+
+    /**
+     * Set the TextWatcher of the edit text.
+     */
+    private fun setupTextWatcher() {
+        if (andesTextareaAttrs.textWatcher != null) {
+            textComponent.addTextChangedListener(andesTextareaAttrs.textWatcher)
+        }
     }
 
     /**

--- a/components/src/main/java/com/mercadolibre/android/andesui/textfield/AndesTextfield.kt
+++ b/components/src/main/java/com/mercadolibre/android/andesui/textfield/AndesTextfield.kt
@@ -129,7 +129,7 @@ class AndesTextfield : ConstraintLayout {
         }
 
     /**
-     * Getter and setter for the [rightContent].
+     * Getter and setter for the [textWatcher].
      */
     var textWatcher: TextWatcher?
         get() = andesTextfieldAttrs.textWatcher

--- a/components/src/main/java/com/mercadolibre/android/andesui/textfield/AndesTextfield.kt
+++ b/components/src/main/java/com/mercadolibre/android/andesui/textfield/AndesTextfield.kt
@@ -277,8 +277,9 @@ class AndesTextfield : ConstraintLayout {
      * Set the TextWatcher of the edit text.
      */
     private fun setupTextWatcher() {
-        andesTextfieldAttrs.textWatcher?
+        if (andesTextfieldAttrs.textWatcher != null) {
             textComponent.addTextChangedListener(andesTextfieldAttrs.textWatcher)
+        }
     }
 
     /**

--- a/components/src/main/java/com/mercadolibre/android/andesui/textfield/AndesTextfield.kt
+++ b/components/src/main/java/com/mercadolibre/android/andesui/textfield/AndesTextfield.kt
@@ -128,6 +128,16 @@ class AndesTextfield : ConstraintLayout {
             setupInputType()
         }
 
+    /**
+     * Getter and setter for the [rightContent].
+     */
+    var textWatcher: TextWatcher?
+        get() = andesTextfieldAttrs.textWatcher
+        set(value) {
+            andesTextfieldAttrs = andesTextfieldAttrs.copy(textWatcher = value)
+            setupTextWatcher()
+        }
+
     private lateinit var andesTextfieldAttrs: AndesTextfieldAttrs
     private lateinit var textfieldContainer: ConstraintLayout
     private lateinit var textContainer: ConstraintLayout
@@ -201,6 +211,7 @@ class AndesTextfield : ConstraintLayout {
         setupRightComponent(config)
         setupColorComponents(config)
         setupInputType()
+        setupTextWatcher()
         setupTextComponent(config)
     }
 
@@ -260,6 +271,15 @@ class AndesTextfield : ConstraintLayout {
      */
     private fun setupInputType() {
         textComponent.inputType = inputType
+    }
+
+    /**
+     * Set the TextWatcher of the edit text.
+     */
+    private fun setupTextWatcher() {
+        if (andesTextfieldAttrs.textWatcher != null) {
+            textComponent.addTextChangedListener(andesTextfieldAttrs.textWatcher)
+        }
     }
 
     /**

--- a/components/src/main/java/com/mercadolibre/android/andesui/textfield/factory/AndesTexfieldAttrsParser.kt
+++ b/components/src/main/java/com/mercadolibre/android/andesui/textfield/factory/AndesTexfieldAttrsParser.kt
@@ -2,6 +2,7 @@ package com.mercadolibre.android.andesui.textfield.factory
 
 import android.content.Context
 import android.text.InputType
+import android.text.TextWatcher
 import android.util.AttributeSet
 import com.mercadolibre.android.andesui.R
 import com.mercadolibre.android.andesui.textfield.content.AndesTextfieldLeftContent
@@ -19,7 +20,8 @@ internal data class AndesTextfieldAttrs(
     val state: AndesTextfieldState,
     val leftContent: AndesTextfieldLeftContent?,
     val rightContent: AndesTextfieldRightContent?,
-    val inputType: Int
+    val inputType: Int,
+    val textWatcher: TextWatcher? = null
 )
 
 /**

--- a/components/src/main/java/com/mercadolibre/android/andesui/textfield/factory/AndesTextareaAttrsParser.kt
+++ b/components/src/main/java/com/mercadolibre/android/andesui/textfield/factory/AndesTextareaAttrsParser.kt
@@ -1,6 +1,7 @@
 package com.mercadolibre.android.andesui.textfield.factory
 
 import android.content.Context
+import android.text.TextWatcher
 import android.util.AttributeSet
 import com.mercadolibre.android.andesui.R
 import com.mercadolibre.android.andesui.textfield.state.AndesTextfieldState
@@ -14,7 +15,8 @@ internal data class AndesTextareaAttrs(
     val placeholder: String?,
     val counter: Int,
     val state: AndesTextfieldState,
-    val maxLines: Int?
+    val maxLines: Int?,
+    val textWatcher: TextWatcher? = null
 )
 
 /**

--- a/components/src/main/java/com/mercadolibre/android/andesui/textfield/factory/AndesTextfieldConfigurationFactory.kt
+++ b/components/src/main/java/com/mercadolibre/android/andesui/textfield/factory/AndesTextfieldConfigurationFactory.kt
@@ -3,6 +3,7 @@ package com.mercadolibre.android.andesui.textfield.factory
 import android.content.Context
 import android.graphics.Typeface
 import android.graphics.drawable.Drawable
+import android.text.TextWatcher
 import android.view.View
 import com.mercadolibre.android.andesui.R
 import com.mercadolibre.android.andesui.color.AndesColor

--- a/components/src/test/java/com/mercadolibre/android/andesui/textfield/AndesTextfieldTest.kt
+++ b/components/src/test/java/com/mercadolibre/android/andesui/textfield/AndesTextfieldTest.kt
@@ -1,6 +1,8 @@
 package com.mercadolibre.android.andesui.textfield
 
 import android.os.Build
+import android.text.Editable
+import android.text.TextWatcher
 import android.view.View
 import com.facebook.common.logging.FLog
 import com.facebook.drawee.backends.pipeline.Fresco
@@ -11,7 +13,7 @@ import com.facebook.soloader.SoLoader
 import com.mercadolibre.android.andesui.BuildConfig
 import com.mercadolibre.android.andesui.textfield.content.AndesTextfieldLeftContent
 import com.mercadolibre.android.andesui.textfield.content.AndesTextfieldRightContent
-import junit.framework.Assert.assertEquals
+import junit.framework.Assert.*
 import org.junit.Before
 import org.junit.BeforeClass
 import org.junit.Test
@@ -75,4 +77,23 @@ class AndesTextfieldTest {
         textfield.setAction("action", View.OnClickListener { })
         assertEquals(textfield.rightContent, AndesTextfieldRightContent.ACTION)
     }
+
+    @Test
+    fun `textfield with watcher`() {
+        val watcher = object : TextWatcher {
+            override fun onTextChanged(s: CharSequence, start: Int, before: Int, count: Int) {}
+
+            override fun beforeTextChanged(s: CharSequence, start: Int, count: Int, after: Int) {}
+
+            override fun afterTextChanged(s: Editable) {}
+        }
+        textfield.textWatcher = watcher
+        assertNotNull(textfield.textWatcher)
+    }
+
+    @Test
+    fun `textfield without watcher`() {
+        assertNull(textfield.textWatcher)
+    }
+
 }

--- a/demoapp/src/main/java/com/mercadolibre/android/andesui/demoapp/feature/TextfieldShowcaseActivity.kt
+++ b/demoapp/src/main/java/com/mercadolibre/android/andesui/demoapp/feature/TextfieldShowcaseActivity.kt
@@ -22,7 +22,6 @@ import com.mercadolibre.android.andesui.textfield.content.AndesTextfieldLeftCont
 import com.mercadolibre.android.andesui.textfield.content.AndesTextfieldRightContent
 import com.mercadolibre.android.andesui.textfield.state.AndesTextfieldState
 
-
 class TextfieldShowcaseActivity : AppCompatActivity() {
 
     override fun onCreate(savedInstanceState: Bundle?) {

--- a/demoapp/src/main/java/com/mercadolibre/android/andesui/demoapp/feature/TextfieldShowcaseActivity.kt
+++ b/demoapp/src/main/java/com/mercadolibre/android/andesui/demoapp/feature/TextfieldShowcaseActivity.kt
@@ -6,7 +6,9 @@ import android.support.v4.content.ContextCompat
 import android.support.v4.view.PagerAdapter
 import android.support.v4.view.ViewPager
 import android.support.v7.app.AppCompatActivity
+import android.text.Editable
 import android.text.InputType
+import android.text.TextWatcher
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
@@ -19,6 +21,7 @@ import com.mercadolibre.android.andesui.textfield.AndesTextfield
 import com.mercadolibre.android.andesui.textfield.content.AndesTextfieldLeftContent
 import com.mercadolibre.android.andesui.textfield.content.AndesTextfieldRightContent
 import com.mercadolibre.android.andesui.textfield.state.AndesTextfieldState
+
 
 class TextfieldShowcaseActivity : AppCompatActivity() {
 
@@ -213,6 +216,19 @@ class TextfieldShowcaseActivity : AppCompatActivity() {
             // Set action clear
             val textfield1 = layoutTextfield.findViewById<AndesTextfield>(R.id.andesTextfield1)
             textfield1.text = context.resources.getString(R.string.andesui_demoapp_textfield_placeholder)
+            textfield1.textWatcher = object : TextWatcher {
+                override fun onTextChanged(s: CharSequence, start: Int, before: Int, count: Int) {
+                    Toast.makeText(context, "Text changed: $s", Toast.LENGTH_SHORT).show()
+                }
+
+                override fun beforeTextChanged(s: CharSequence, start: Int, count: Int, after: Int) {
+                    // TODO Auto-generated method stub
+                }
+
+                override fun afterTextChanged(s: Editable) {
+                    // TODO Auto-generated method stub
+                }
+            }
 
             // Set text
             val textfield2 = layoutTextfield.findViewById<AndesTextfield>(R.id.andesTextfield2)

--- a/demoapp/src/main/res/raw/andesui_demoapp_changelog.md
+++ b/demoapp/src/main/res/raw/andesui_demoapp_changelog.md
@@ -1,3 +1,7 @@
+# v2.5.1
+## Added
+- Add TextWatcher in TextField and TextArea
+
 # v2.5.0
 ## Added
 - TAG Component.

--- a/gradle.properties
+++ b/gradle.properties
@@ -58,7 +58,7 @@ kotlinVersion=1.3.40
 detektVersion=1.3.1
 
 # These two are for the test application only. Use libraryVersion to tell your backend which version of the app is.
-demoAppVersionCode=2
+demoAppVersionCode=4
 
 ##################################################################################
 # Production dependencies version

--- a/gradle.properties
+++ b/gradle.properties
@@ -39,7 +39,7 @@ libraryGroupId=com.mercadolibre.android.andesui
 # IMPORTANT: We're using http://semver.org/ for all Android projects, please remember to follow this convention.
 # IMPORTANT: The version will be THE SAME for all modules.
 # For libraryVersion do NOT add a qualifier to this version like LOCAL/EXPERIMENTAL (it'll be added automatically!)
-libraryVersion=2.5.0
+libraryVersion=2.5.1
 
 ##################################################################################
 # Project setup


### PR DESCRIPTION
### Thanks for starting a pull request on Andes UI!

## Description
Se agregó TextWatcher en el TextField y TextArea. Era requerido por algunos equipos para poder tener un listener cuando el TextField cambiara.

## Checks
Are you sure you followed all those steps? In such case, let's say with me "I solemnly declare that ...":
- [X] I have coded an example inside the Demo App,
- [ ] I have added proper tests,
- [X] I have modified the [Changelog](https://github.com/mercadolibre/fury_andesui-android/blob/develop/CHANGELOG.md) file,
- [ ] I have updated GitHub wiki,
- [ ] I have the explicit approval of one or more members of the UX Team,
- [ ] I have updated the version in gradle.properties file.

## Change type
This is easy, let us know what this code is about:
- [ ] This code adds a new component
- [X] This code includes improvements to an existent component
- [ ] This code improves or modifies ONLY the Demo App.

## Check common errors
Whether you are an Android or iOS developer and if you're still there then we'll give you a present:
https://proandroiddev.com/how-to-maximize-androids-ui-reusability-5-common-mistakes-cb2571216a9f
