### PR TITLE
Add showCounter and setTextAction

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 # v2.5.1
 ## Added
-- Add TextWatcher in TextField and TextArea
+- Add TextWatcher in TextField and TextArea.
+- ShowCounter attribute added.
+- The cursor position at the end of the text is set when changing the type.
 
 # v2.5.0
 ## Added

--- a/components/src/main/java/com/mercadolibre/android/andesui/textfield/AndesTextfield.kt
+++ b/components/src/main/java/com/mercadolibre/android/andesui/textfield/AndesTextfield.kt
@@ -38,6 +38,7 @@ class AndesTextfield : ConstraintLayout {
         get() = textComponent.text.toString()
         set(value) {
             textComponent.setText(value)
+            setupCounterComponent(createConfig())
         }
 
     /**
@@ -79,6 +80,16 @@ class AndesTextfield : ConstraintLayout {
         get() = andesTextfieldAttrs.counter
         set(value) {
             andesTextfieldAttrs = andesTextfieldAttrs.copy(counter = value)
+            setupCounterComponent(createConfig())
+        }
+
+    /**
+     * Getter and setter for [showCounter].
+     */
+    var showCounter: Boolean
+        get() = andesTextfieldAttrs.showCounter
+        set(value) {
+            andesTextfieldAttrs = andesTextfieldAttrs.copy(showCounter = value)
             setupCounterComponent(createConfig())
         }
 
@@ -151,7 +162,8 @@ class AndesTextfield : ConstraintLayout {
 
     @Suppress("unused")
     constructor(context: Context) : super(context) {
-        initAttrs(LABEL_DEFAULT, HELPER_DEFAULT, PLACEHOLDER_DEFAULT, COUNTER_DEFAULT, STATE_DEFAULT, LEFT_COMPONENT_DEFAULT, RIGHT_COMPONENT_DEFAULT, INPUT_TYPE_DEFAULT)
+        initAttrs(LABEL_DEFAULT, HELPER_DEFAULT, PLACEHOLDER_DEFAULT, COUNTER_DEFAULT,
+                  STATE_DEFAULT, LEFT_COMPONENT_DEFAULT, RIGHT_COMPONENT_DEFAULT, INPUT_TYPE_DEFAULT)
     }
 
     constructor(
@@ -164,8 +176,7 @@ class AndesTextfield : ConstraintLayout {
         leftContent: AndesTextfieldLeftContent? = LEFT_COMPONENT_DEFAULT,
         rightContent: AndesTextfieldRightContent? = RIGHT_COMPONENT_DEFAULT,
         inputType: Int = INPUT_TYPE_DEFAULT
-    ) :
-            super(context) {
+    ) : super(context) {
         initAttrs(label, helper, placeholder, counter, state, leftContent, rightContent, inputType)
     }
 
@@ -193,7 +204,10 @@ class AndesTextfield : ConstraintLayout {
         rightContent: AndesTextfieldRightContent?,
         inputType: Int
     ) {
-        andesTextfieldAttrs = AndesTextfieldAttrs(label, helper, placeholder, counter, state, leftContent, rightContent, inputType)
+        val showCounter = SHOW_COUNTER_DEFAULT
+        andesTextfieldAttrs = AndesTextfieldAttrs(
+                label, helper, placeholder, counter, showCounter, state, leftContent, rightContent, inputType
+        )
         val config = AndesTextfieldConfigurationFactory.create(context, andesTextfieldAttrs)
         setupComponents(config)
     }
@@ -271,6 +285,7 @@ class AndesTextfield : ConstraintLayout {
      */
     private fun setupInputType() {
         textComponent.inputType = inputType
+        textComponent.setSelection(textComponent.text.length)
     }
 
     /**
@@ -339,7 +354,7 @@ class AndesTextfield : ConstraintLayout {
      * Gets data from the config and sets to the Counter component.
      */
     private fun setupCounterComponent(config: AndesTextfieldConfiguration) {
-        if (config.counterLength != 0 && state != READONLY) {
+        if (config.counterLength != 0 && state != READONLY && showCounter) {
             counterComponent.visibility = View.VISIBLE
             counterComponent.setTextSize(TypedValue.COMPLEX_UNIT_PX, config.counterSize)
             counterComponent.text = resources.getString(R.string.andes_textfield_counter_text, 0, config.counterLength)
@@ -457,6 +472,16 @@ class AndesTextfield : ConstraintLayout {
     }
 
     /**
+     * Set the right content to action and provides an interface to set button text.
+     */
+    fun setTextAction(text: String) {
+        if (rightComponent.getChildAt(0) is AndesButton) {
+            val action: AndesButton = rightComponent.getChildAt(0) as AndesButton
+            action.text = text
+        }
+    }
+
+    /**
      * Set the right content to icon and provides an interface to give the icon path.
      */
     fun setRightIcon(iconPath: String) {
@@ -510,6 +535,7 @@ class AndesTextfield : ConstraintLayout {
         private val HELPER_DEFAULT = null
         private val PLACEHOLDER_DEFAULT = null
         private val COUNTER_DEFAULT = 0
+        private val SHOW_COUNTER_DEFAULT = true
         private val STATE_DEFAULT = IDLE
         private val LEFT_COMPONENT_DEFAULT = null
         private val RIGHT_COMPONENT_DEFAULT = null

--- a/components/src/main/java/com/mercadolibre/android/andesui/textfield/factory/AndesTexfieldAttrsParser.kt
+++ b/components/src/main/java/com/mercadolibre/android/andesui/textfield/factory/AndesTexfieldAttrsParser.kt
@@ -17,6 +17,7 @@ internal data class AndesTextfieldAttrs(
     val helper: String?,
     val placeholder: String?,
     val counter: Int,
+    val showCounter: Boolean = true,
     val state: AndesTextfieldState,
     val leftContent: AndesTextfieldLeftContent?,
     val rightContent: AndesTextfieldRightContent?,

--- a/demoapp/src/main/res/raw/andesui_demoapp_changelog.md
+++ b/demoapp/src/main/res/raw/andesui_demoapp_changelog.md
@@ -1,3 +1,7 @@
+# v2.5.1
+## Added
+- Add TextWatcher in TextField and TextArea
+
 # v2.5.0
 ## Added
 - TAG Component.


### PR DESCRIPTION
### Thanks for starting a pull request on Andes UI!

## Description
- Se da la opción que el counter sea visible o no.
- Se da la opción de cambiar sólo el suffix sin necesidad de pasarle el listener.

## Checks
Are you sure you followed all those steps? In such case, let's say with me "I solemnly declare that ...":
- [ ] I have coded an example inside the Demo App,
- [ ] I have added proper tests,
- [X] I have modified the [Changelog](https://github.com/mercadolibre/fury_andesui-android/blob/develop/CHANGELOG.md) file,
- [ ] I have updated GitHub wiki,
- [ ] I have the explicit approval of one or more members of the UX Team,
- [X] I have updated the version in gradle.properties file.

## Change type
This is easy, let us know what this code is about:
- [ ] This code adds a new component
- [X] This code includes improvements to an existent component
- [ ] This code improves or modifies ONLY the Demo App.

## Check common errors
Whether you are an Android or iOS developer and if you're still there then we'll give you a present:
https://proandroiddev.com/how-to-maximize-androids-ui-reusability-5-common-mistakes-cb2571216a9f
