### PR TITLE
Many linters improvements to improve the developer experience

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,7 @@ bintray.properties
 config/*
 ## Not ignoring detekt configuration file
 !config/detekt.yml
+!config/android/android-lint-components.xml
 
 ## Gradle
 .gradle

--- a/components/build.gradle
+++ b/components/build.gradle
@@ -32,10 +32,6 @@ android {
         }
     }
 
-    lintOptions {
-        disable 'IconDuplicates'
-    }
-
     testOptions {
         unitTests {
             includeAndroidResources = true
@@ -57,7 +53,8 @@ android {
 staticCodeAnalysis {
     // False is REQUIRED in order to make CI server fail the build on errors and fit cross company standards.
     ignoreErrors = false
-    findbugs = false
+
+    androidLintConfig = "$project.rootProject.projectDir/config/android/android-lint-components.xml"
 }
 
 dependencies {

--- a/components/src/main/res/badge/layout/andes_layout_badge_pill.xml
+++ b/components/src/main/res/badge/layout/andes_layout_badge_pill.xml
@@ -19,6 +19,8 @@
         app:layout_constraintBottom_toBottomOf="parent"
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintTop_toTopOf="parent" />
+        app:layout_constraintTop_toTopOf="parent"
+        tools:ignore="SmallSp" />
+    <!-- tools:ignore="SmallSp" ignored but should be checked with UX -->
 
 </merge>

--- a/components/src/main/res/layout/andes_layout_card.xml
+++ b/components/src/main/res/layout/andes_layout_card.xml
@@ -77,7 +77,9 @@
             android:tint="@color/andes_accent_color_500"
             app:layout_constraintStart_toEndOf="@+id/andes_card_title_link"
             app:layout_constraintTop_toTopOf="@+id/andes_card_title_link"
-            app:srcCompat="@drawable/andes_ui_chevron_right_20" />
+            app:srcCompat="@drawable/andes_ui_chevron_right_20"
+            tools:ignore="ContentDescription" />
+        <!-- tools:ignore="ContentDescription" ignored but should be checked with UX -->
 
         <android.support.constraint.Group
             android:id="@+id/group_card"

--- a/components/src/main/res/progress/values/dimens_progress.xml
+++ b/components/src/main/res/progress/values/dimens_progress.xml
@@ -1,14 +1,15 @@
 <?xml version="1.0" encoding="utf-8"?>
-<resources>
+<resources xmlns:tools="http://schemas.android.com/tools" >
 
     <dimen name="andes_progress_xlarge">48dp</dimen>
     <dimen name="andes_progress_large">32dp</dimen>
     <dimen name="andes_progress_medium">24dp</dimen>
     <dimen name="andes_progress_small">16dp</dimen>
 
-    <dimen name="andes_progress_stroke_xlarge">8px</dimen>
-    <dimen name="andes_progress_stroke_large">7px</dimen>
-    <dimen name="andes_progress_stroke_medium">6px</dimen>
-    <dimen name="andes_progress_stroke_small">5px</dimen>
+    <!-- tools:ignore="PxUsage" added because using dp breaks the stroke, we need to be very accurate. -->
+    <dimen name="andes_progress_stroke_xlarge" tools:ignore="PxUsage">8px</dimen>
+    <dimen name="andes_progress_stroke_large" tools:ignore="PxUsage">7px</dimen>
+    <dimen name="andes_progress_stroke_medium" tools:ignore="PxUsage">6px</dimen>
+    <dimen name="andes_progress_stroke_small" tools:ignore="PxUsage">5px</dimen>
 
 </resources>

--- a/components/src/main/res/textfield/layout/andes_layout_checkbox.xml
+++ b/components/src/main/res/textfield/layout/andes_layout_checkbox.xml
@@ -2,6 +2,7 @@
 <android.support.constraint.ConstraintLayout
     xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
     android:id="@+id/andes_checkbox_container"
     android:layout_width="wrap_content"
     android:layout_height="wrap_content">
@@ -22,12 +23,15 @@
             app:layout_constraintBottom_toBottomOf="@id/andes_checkbox_container"
             app:layout_constraintEnd_toStartOf="@+id/checkboxText"
             app:layout_constraintStart_toStartOf="@id/andes_checkbox_container"
-            app:layout_constraintTop_toTopOf="@+id/andes_checkbox_container">
+            app:layout_constraintTop_toTopOf="@+id/andes_checkbox_container"
+            tools:ignore="UselessParent">
 
             <ImageView
                 android:id="@+id/leftCheckboxIcon"
                 android:layout_width="match_parent"
-                android:layout_height="match_parent" />
+                android:layout_height="match_parent"
+                tools:ignore="ContentDescription" />
+            <!-- tools:ignore="ContentDescription" ignored but should be checked with UX -->
 
         </FrameLayout>
 
@@ -60,12 +64,15 @@
             app:layout_constraintBottom_toBottomOf="@+id/andes_checkbox_container"
             app:layout_constraintEnd_toEndOf="@id/andes_checkbox_container"
             app:layout_constraintStart_toEndOf="@+id/checkboxText"
-            app:layout_constraintTop_toTopOf="@+id/andes_checkbox_container">
+            app:layout_constraintTop_toTopOf="@+id/andes_checkbox_container"
+            tools:ignore="UselessParent">
 
             <ImageView
                 android:id="@+id/rightCheckboxIcon"
                 android:layout_width="match_parent"
-                android:layout_height="match_parent" />
+                android:layout_height="match_parent"
+                tools:ignore="ContentDescription" />
+            <!-- tools:ignore="ContentDescription" ignored but should be checked with UX -->
 
         </FrameLayout>
 

--- a/components/src/main/res/textfield/layout/andes_layout_textarea.xml
+++ b/components/src/main/res/textfield/layout/andes_layout_textarea.xml
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <android.support.constraint.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
     android:id="@+id/andes_textarea_container"
     android:layout_width="match_parent"
     android:layout_height="wrap_content">
@@ -43,7 +44,9 @@
             app:layout_constraintHorizontal_bias="0.0"
             app:layout_constraintStart_toStartOf="@+id/andes_textarea_text_container"
             app:layout_constraintTop_toTopOf="@id/andes_textarea_text_container"
-            app:layout_constraintVertical_bias="1.0" />
+            app:layout_constraintVertical_bias="1.0"
+            tools:ignore="LabelFor" />
+        <!-- tools:ignore="LabelFor" ignored but should be checked with UX -->
 
     </android.support.constraint.ConstraintLayout>
 

--- a/components/src/main/res/textfield/layout/andes_layout_textfield.xml
+++ b/components/src/main/res/textfield/layout/andes_layout_textfield.xml
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <android.support.constraint.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
     android:id="@+id/andes_textfield_container"
     android:layout_width="match_parent"
     android:layout_height="wrap_content">
@@ -51,7 +52,9 @@
             app:layout_constraintStart_toEndOf="@+id/andes_textfield_left_component"
             app:layout_constraintTop_toTopOf="parent"
             app:layout_goneMarginEnd="@dimen/andes_textfield_margin"
-            app:layout_goneMarginStart="@dimen/andes_textfield_margin" />
+            app:layout_goneMarginStart="@dimen/andes_textfield_margin"
+            tools:ignore="LabelFor" />
+        <!-- tools:ignore="LabelFor" ignored but should be checked with UX -->
 
         <FrameLayout
             android:id="@+id/andes_textfield_right_component"

--- a/components/src/main/res/textfield/values/dimens_textfield.xml
+++ b/components/src/main/res/textfield/values/dimens_textfield.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
     <dimen name="andes_textfield_label_paddingLeft">6dp</dimen>
-    <dimen name="andes_textfield_label_textSize">14dp</dimen>
+    <dimen name="andes_textfield_label_textSize">14sp</dimen>
 
     <dimen name="andes_textfield_container_marginTop">4dp</dimen>
     <dimen name="andes_textfield_container_minHeight">50dp</dimen>

--- a/components/src/main/res/thumbnail/layout/andes_layout_thumbnail.xml
+++ b/components/src/main/res/thumbnail/layout/andes_layout_thumbnail.xml
@@ -5,6 +5,7 @@
     android:layout_width="wrap_content"
     android:layout_height="wrap_content"
     tools:parentTag="FrameLayout" >
+
     <ImageView
         android:id="@+id/andes_thumbnail_image"
         android:layout_width="@dimen/andes_thumbnail_size_24"
@@ -13,5 +14,7 @@
         app:layout_constraintBottom_toBottomOf="parent"
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintTop_toTopOf="parent" />
+        app:layout_constraintTop_toTopOf="parent"
+        tools:ignore="ContentDescription" />
+    <!-- tools:ignore="ContentDescription" ignored but should be checked with UX -->
 </merge>

--- a/config/android/android-lint-components.xml
+++ b/config/android/android-lint-components.xml
@@ -1,0 +1,111 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<lint>
+    <!-- The following are NOT the only checks that Lint runs, just severity overrides -->
+
+    <!-- Correctness -->
+    <issue id="DefaultLocale" severity="warning" />
+    <issue id="DuplicateIncludedIds" severity="error" />
+    <issue id="GradleDependency" severity="warning" />
+    <issue id="InflateParams" severity="error" />
+    <issue id="InlinedApi" severity="error" />
+    <issue id="InvalidPackage" severity="warning" />
+    <issue id="MissingId" severity="error" />
+    <issue id="NewerVersionAvailable" severity="warning" />
+    <issue id="OldTargetApi" severity="warning" />
+    <issue id="PrivateResource" severity="error" />
+    <issue id="Registered" severity="error" />
+    <issue id="ScrollViewSize" severity="warning" />
+    <issue id="UnusedAttribute" severity="warning" />
+    <issue id="SpUsage" severity="error" />
+    <issue id="PxUsage" severity="error" />
+
+    <!-- Correctness:Messages -->
+    <issue id="Typos" severity="error" />
+    <issue id="PluralsCandidate" severity="error" />
+    <issue id="StringFormatCount" severity="error" />
+    <issue id="WifiManagerPotentialLeak" severity="error" />
+
+    <!-- Security checks -->
+    <issue id="AddJavascriptInterface" severity="error" />
+    <issue id="AllowBackup" severity="warning" />
+    <issue id="EasterEgg" severity="error" />
+    <issue id="ExportedContentProvider" severity="error" />
+    <issue id="ExportedReceiver" severity="error" />
+    <issue id="ExportedService" severity="error" />
+    <issue id="GrantAllUris" severity="error" />
+    <issue id="PackagedPrivateKey" severity="error" />
+    <issue id="PackageManagerGetSignatures" severity="error" />
+    <issue id="SecureRandom" severity="error" />
+    <issue id="TrulyRandom" severity="error" />
+    <issue id="UseCheckPermission" severity="error" />
+    <issue id="UsingHttp" severity="error" />
+
+    <!-- Performance checks -->
+    <issue id="DisableBaselineAlignment" severity="error" />
+    <issue id="DrawAllocation" severity="error" />
+    <issue id="FieldGetter" severity="error" />
+    <issue id="FloatMath" severity="error" />
+    <issue id="HandlerLeak" severity="error" />
+    <issue id="InefficientWeight" severity="error" />
+    <issue id="LogConditional" severity="error" />
+    <issue id="MergeRootFrame" severity="error" />
+    <issue id="NestedWeights" severity="error" />
+    <issue id="ObsoleteLayoutParam" severity="error" />
+    <issue id="ObsoleteSdkInt" severity="error" />
+    <issue id="Overdraw" severity="warning" />
+    <issue id="Recycle" severity="error" />
+    <issue id="TooDeepLayout" severity="error" />
+    <issue id="TooManyViews" severity="error" />
+    <issue id="UnusedIds" severity="error" />
+    <issue id="UnusedNamespace" severity="error" />
+    <issue id="UnusedResources" severity="error">
+        <ignore regexp=".*_dynamic.*" />
+    </issue>
+    <issue id="UseCompoundDrawables" severity="warning" />
+    <issue id="UselessLeaf" severity="error" />
+    <issue id="UselessParent" severity="error" />
+    <issue id="UseSparseArrays" severity="error" />
+    <issue id="UseValueOf" severity="error" />
+    <issue id="ViewHolder" severity="error" />
+
+    <!-- Usability:Typography -->
+    <issue id="TypographyEllipsis" severity="error" />
+
+    <!-- Usability:Icons -->
+    <issue id="IconDensities" severity="error" />
+    <issue id="IconDipSize" severity="error" />
+    <issue id="IconDuplicates" severity="warning" />
+    <issue id="IconDuplicatesConfig" severity="error" />
+    <issue id="IconExpectedSize" severity="error" />
+    <issue id="IconLocation" severity="error" />
+
+    <!-- Usability -->
+    <issue id="AlwaysShowAction" severity="warning" />
+    <issue id="BackButton" severity="error" />
+    <issue id="GoogleAppIndexingApiWarning" severity="warning" />
+    <issue id="NegativeMargin" severity="error" />
+    <issue id="SelectableText" severity="warning" />
+    <issue id="TextFields" severity="error" />
+    <issue id="ViewConstructor" severity="error" />
+    <issue id="SmallSp" severity="error" />
+
+    <!-- Accessibility -->
+    <issue id="ClickableViewAccessibility" severity="warning" />
+    <issue id="ContentDescription" severity="error" />
+    <issue id="LabelFor" severity="error" />
+
+    <!-- Internationalization -->
+    <issue id="HardcodedText" severity="error" />
+    <issue id="RelativeOverlap" severity="error" />
+    <issue id="SetTextI18n" severity="error" />
+
+    <!-- Internationalization:Bidirectional text -->
+    <issue id="ExtraTranslation" severity="error" />
+    <issue id="MissingTranslation" severity="error">
+        <ignore path="**/strings_by_country.xml" />
+        <ignore path="**/deeplinks.xml" />
+    </issue>
+    <issue id="RtlHardcoded" severity="ignore" />
+    <issue id="RtlSymmetry" severity="ignore" />
+</lint>

--- a/demoapp/build.gradle
+++ b/demoapp/build.gradle
@@ -69,6 +69,8 @@ android {
 staticCodeAnalysis {
     // False is REQUIRED in order to make CI server fail the build on errors.
     ignoreErrors = false
+
+    androidLintConfig = "$project.rootProject.projectDir/config/android/android-lint-demoapp.xml"
 }
 
 dependencies {

--- a/demoapp/src/main/java/com/mercadolibre/android/andesui/demoapp/PageIndicator.java
+++ b/demoapp/src/main/java/com/mercadolibre/android/andesui/demoapp/PageIndicator.java
@@ -4,6 +4,7 @@ import android.content.Context;
 import android.graphics.PorterDuff;
 import android.support.annotation.NonNull;
 import android.support.annotation.Nullable;
+import android.support.v4.view.PagerAdapter;
 import android.support.v4.view.ViewPager;
 import android.util.AttributeSet;
 import android.view.LayoutInflater;
@@ -57,9 +58,14 @@ public class PageIndicator extends LinearLayout implements ViewPager.OnPageChang
      */
     public void attach(@NonNull final ViewPager viewPager) {
         viewPager.addOnPageChangeListener(this);
-        mViews = new ImageView[viewPager.getAdapter().getCount()];
 
-        for (int i = 0; i < viewPager.getAdapter().getCount(); i++) {
+        PagerAdapter pagerAdapter = viewPager.getAdapter();
+        if (pagerAdapter == null) {
+            return;
+        }
+
+        mViews = new ImageView[pagerAdapter.getCount()];
+        for (int i = 0; i < pagerAdapter.getCount(); i++) {
 
             final ImageView view = (ImageView) LayoutInflater.from(getContext())
                     .inflate(R.layout.andesui_widget_page_circle_indicator, this, false);

--- a/gradle.properties
+++ b/gradle.properties
@@ -49,11 +49,9 @@ maxApiLevel=29
 androidBuildToolsVersion=29.0.3
 gradleBuildToolsVersion=3.4.2
 gradleWrapperVersion=5.6.4
-gradlePluginsVersion=6.+
-buildScanPluginVersion=1.16
-scaPluginVersion=2.6.12
+scaPluginVersion=3.2.0
 bintrayReleasePluginVersion=0.9.2
-dexCountGradlePlugin=0.8.5
+dexCountGradlePlugin=1.0.3
 kotlinVersion=1.3.40
 detektVersion=1.3.1
 


### PR DESCRIPTION
Changed many Android Lint linters from warning to error:
- ContentDescription
- PxUsage
- SpUsage
- LabelFor
- UselessParent

Upgraded dexCountGradlePlugin to latest stable release v1.0.3.
Upgraded staticCodeAnalysis to latest stable release v3.2.0 which replace Findbugs with Spotbus.

Also I removed unused properties from `gradle.properties`

PR will continue in another one by fixing & upgrading Detekt.