### PR TITLE
Fix IconDuplicates severity for Android Lint [Trivial]

### DIFF
--- a/config/android/android-lint-components.xml
+++ b/config/android/android-lint-components.xml
@@ -75,7 +75,7 @@
     <!-- Usability:Icons -->
     <issue id="IconDensities" severity="error" />
     <issue id="IconDipSize" severity="error" />
-    <issue id="IconDuplicates" severity="warning" />
+    <issue id="IconDuplicates" severity="error" />
     <issue id="IconDuplicatesConfig" severity="error" />
     <issue id="IconExpectedSize" severity="error" />
     <issue id="IconLocation" severity="error" />


### PR DESCRIPTION
Simply change severity from warning to error to add another check for the Android Lint