### PR TITLE
Fix thumbnail image aspect ratio

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,9 @@
 - Libraries upgraded from unit tests and showcase module.
 - Gradle files cleanup.
 
+## 🛠 Fixes
+- AndesThumbnail: Use internal ImageView content drawable to keep aspect ratio. | Author: [@mzangl-meli](https://github.com/mzangl-meli)
+
 # v2.10.1
 ## 🛠 Fixes
 - AndesProgressIndicatorIndeterminate: Leak in progress animation | Author: [@orelvismeli](https://github.com/orelvismeli)

--- a/components/src/main/java/com/mercadolibre/android/andesui/thumbnail/AndesThumbnail.kt
+++ b/components/src/main/java/com/mercadolibre/android/andesui/thumbnail/AndesThumbnail.kt
@@ -196,13 +196,13 @@ class AndesThumbnail : FrameLayout {
         val unwrappedDrawable = config.image
         val wrappedDrawable = DrawableCompat.wrap(unwrappedDrawable)
 
-        imageFrame.background = wrappedDrawable
+        imageFrame.setImageDrawable(wrappedDrawable)
         setupImageColor(config.iconColor)
         setupImageSize(config.iconSize)
     }
 
     private fun setupImageColor(iconColor: AndesColor) {
-        DrawableCompat.setTint(imageFrame.background, iconColor.colorInt(context))
+        DrawableCompat.setTint(imageFrame.drawable, iconColor.colorInt(context))
     }
 
     private fun setupImageSize(iconSize: Int) {

--- a/demoapp/src/main/res/layout/andesui_demoapp_main.xml
+++ b/demoapp/src/main/res/layout/andesui_demoapp_main.xml
@@ -172,7 +172,7 @@
             app:andesButtonHierarchy="loud"
             app:andesButtonSize="large"
             app:andesButtonText="@string/andesui_demoapp_progress"
-            app:layout_constraintTop_toBottomOf="@id/andesui_textfield" />
+            app:layout_constraintTop_toBottomOf="@id/andesui_thumbnail" />
 
         <TextView
             android:id="@+id/andesui_demoapp_label_more"


### PR DESCRIPTION
## Motivation
Issue -> https://github.com/mercadolibre/fury_andesui-android/issues/150
## Description
There is a problem to keep the aspect ratio on a Thumbnail drawable. The current fix uses the internal ImageView drawable content, and when its size change, the drawable content keeps the corresponding aspect ratio. 
## Affected component
Thumbnail


## Screenshots
<img src=https://user-images.githubusercontent.com/63661111/93373065-2ff3a400-f82b-11ea-9141-0f0bfc2972ac.png width=300>

## Checks
Are you sure you followed all those steps? In such case, let's say with me "I solemnly declare that ...":
- [ ] I have coded an example inside the Demo App,
- [ ] I have added proper tests,
- [X] I have modified the [Changelog](https://github.com/mercadolibre/fury_andesui-android/blob/develop/CHANGELOG.md) file,
- [ ] I have updated GitHub wiki,
- [ ] I have the explicit approval of one or more members of the UX Team,
- [ ] I have updated the version in gradle.properties file.

## Change type
This is easy, let us know what this code is about:
- [X] This code includes improvements to an existent component

## Check common errors
Whether you are an Android or iOS developer and if you're still there then we'll give you a present:
https://proandroiddev.com/how-to-maximize-androids-ui-reusability-5-common-mistakes-cb2571216a9f
