### PR TITLE
Enable "Show Taps" for API 22 and below

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# v2.12.0
+## 🚀 Features
+- Auto enable Show Taps option when Android version is API 22 or below.
+
 # v2.11.0
 ## 🚀 Features
 - Changed target API level to 29.

--- a/demoapp/src/main/AndroidManifest.xml
+++ b/demoapp/src/main/AndroidManifest.xml
@@ -6,6 +6,8 @@
     <uses-permission android:name="android.permission.INTERNET" />
     <uses-permission android:name="android.permission.ACCESS_NETWORK_STATE" />
     <uses-permission android:name="android.permission.READ_EXTERNAL_STORAGE" />
+    <uses-permission android:name="android.permission.WRITE_SETTINGS"
+        tools:ignore="ProtectedPermissions" />
 
     <application
         android:name=".MainApplication"

--- a/demoapp/src/main/java/com/mercadolibre/android/andesui/demoapp/MainApplication.kt
+++ b/demoapp/src/main/java/com/mercadolibre/android/andesui/demoapp/MainApplication.kt
@@ -2,6 +2,8 @@ package com.mercadolibre.android.andesui.demoapp
 
 import android.app.Application
 import android.content.Context
+import android.os.Build
+import android.provider.Settings
 import android.support.multidex.MultiDex
 import com.facebook.common.logging.FLog
 import com.facebook.drawee.backends.pipeline.Fresco
@@ -19,6 +21,10 @@ class MainApplication : Application() {
         // No need for productFlavors, as proguard will remove all multidex related code in non-debug builds.
         if (BuildConfig.BUILD_TYPE.contentEquals("debug")) {
             MultiDex.install(this)
+        }
+
+        if (Build.VERSION.SDK_INT < Build.VERSION_CODES.M) {
+            Settings.System.putInt(base.contentResolver, "show_touches", 1)
         }
     }
 

--- a/demoapp/src/main/res/raw/andesui_demoapp_changelog.md
+++ b/demoapp/src/main/res/raw/andesui_demoapp_changelog.md
@@ -1,3 +1,7 @@
+# v2.12.0
+## 🚀 Features
+- Auto enable Show Taps option when Android version is API 22 or below.
+
 # v2.11.0
 ## 🚀 Features
 - Changed target API level to 29.
@@ -10,6 +14,9 @@
 - Apply many suggestions from Detekt to both components and showcase modules. Ignore others in favor of enable linters from now on.
 - Libraries upgraded from unit tests and showcase module.
 - Gradle files cleanup.
+
+## 🛠 Fixes
+- AndesThumbnail: Use internal ImageView content drawable to keep aspect ratio. | Author: [@mzangl-meli](https://github.com/mzangl-meli)
 
 # v2.10.1
 ## 🛠 Fixes

--- a/gradle.properties
+++ b/gradle.properties
@@ -39,7 +39,7 @@ libraryGroupId=com.mercadolibre.android.andesui
 # IMPORTANT: We're using http://semver.org/ for all Android projects, please remember to follow this convention.
 # IMPORTANT: The version will be THE SAME for all modules.
 # For libraryVersion do NOT add a qualifier to this version like LOCAL/EXPERIMENTAL (it'll be added automatically!)
-libraryVersion=2.11.0
+libraryVersion=2.12.0
 
 ##################################################################################
 # Project setup


### PR DESCRIPTION
## Motivation
Added auto enabling of Show Taps on API 22 and below.

## Description
It writes the System Permissions and enables a Developer Option. 

## Why do we need this?
Because it's highly useful when we record a GIF showing a new feature.

## Affected component
Demo App

## Screenshots
![show taps](https://user-images.githubusercontent.com/35068259/94599477-dd70a980-0266-11eb-8318-59724a27ad08.gif)

## Checks
Are you sure you followed all those steps? In such case, let's say with me "I solemnly declare that ...":
- [x] I have coded an example inside the Demo App,
- [ ] I have added proper tests,
- [x] I have modified the [Changelog](https://github.com/mercadolibre/fury_andesui-android/blob/develop/CHANGELOG.md) file,
- [ ] I have updated GitHub wiki,
- [ ] I have the explicit approval of one or more members of the UX Team,
- [x] I have updated the version in gradle.properties file.

## Change type
This is easy, let us know what this code is about:
- [ ] This code adds a new component
- [ ] This code includes improvements to an existent component
- [x] This code improves or modifies ONLY the Demo App.
