### PR TITLE
Add Leak Canary v2.5 to debug builds

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,12 @@
 # v2.13.0
 ## Added
 - Added Andes icons (bill, cash, credit card, shipping, wallet)
+
 ## 🛠 Fixes
 - Refactor AndesTag
+
+## Developer Experience
+- Added LeakCanary v2.5 to debug builds to detect memory leaks in an early stage.
 
 # v2.12.0
 ## 🚀 Features

--- a/demoapp/build.gradle
+++ b/demoapp/build.gradle
@@ -83,6 +83,7 @@ dependencies {
 
     implementation showcase.glide
     implementation showcase.markwon
+    debugImplementation showcase.leakCanary
 }
 
 /**

--- a/demoapp/src/main/res/raw/andesui_demoapp_changelog.md
+++ b/demoapp/src/main/res/raw/andesui_demoapp_changelog.md
@@ -1,3 +1,13 @@
+# v2.13.0
+## Added
+- Added Andes icons (bill, cash, credit card, shipping, wallet)
+
+## 🛠 Fixes
+- Refactor AndesTag
+
+## Developer Experience
+- Added LeakCanary v2.5 to debug builds to detect memory leaks in an early stage.
+
 # v2.12.0
 ## 🚀 Features
 - Andes coachmark | Author: [@Marcos Picco](https://github.com/marcospicco)

--- a/dependencies.gradle
+++ b/dependencies.gradle
@@ -35,6 +35,7 @@ ext {
              * It let us show the What's New which is in markdown format.
              * https://github.com/noties/Markwon
              */
-            markwon: 'io.noties.markwon:core:4.5.1'
+            markwon: 'io.noties.markwon:core:4.5.1',
+            leakCanary: 'com.squareup.leakcanary:leakcanary-android:2.5'
     ]
 }


### PR DESCRIPTION
## Motivation
We want to detect memory leak in an early stage.

## Description
Added leak canary to debug builds only.
It can be disabled from the LeakCanary icon launcher => About section if necessary.

## Affected component
None

## Checks
Are you sure you followed all those steps? In such case, let's say with me "I solemnly declare that ...":
- [ ] I have coded an example inside the Demo App,
- [ ] I have added proper tests,
- [X] I have modified the [Changelog](https://github.com/mercadolibre/fury_andesui-android/blob/develop/CHANGELOG.md) file,
- [ ] I have updated GitHub wiki,
- [ ] I have the explicit approval of one or more members of the UX Team,
- [X] I have updated the version in gradle.properties file.

## Change type
This is easy, let us know what this code is about:
- [ ] This code adds a new component
- [ ] This code includes improvements to an existent component
- [X] This code improves or modifies ONLY the Demo App.