### PR TITLE
Fix/ set checkbox component clickable

### DIFF
--- a/components/src/main/java/com/mercadolibre/android/andesui/checkbox/AndesCheckbox.kt
+++ b/components/src/main/java/com/mercadolibre/android/andesui/checkbox/AndesCheckbox.kt
@@ -130,12 +130,11 @@ class AndesCheckbox : ConstraintLayout {
     private fun initComponents() {
         val container = LayoutInflater.from(context).inflate(R.layout.andes_layout_checkbox, this)
         containerCheckbox = container.findViewById(R.id.andes_checkbox_container)
-        onCheckedChangeListener(containerLeftCheckbox)
-        onCheckedChangeListener(containerRightCheckbox)
+        onCheckedChangeListener(containerCheckbox)
     }
 
-    private fun onCheckedChangeListener(checkbox: FrameLayout) {
-        checkbox.setOnClickListener {
+    private fun onCheckedChangeListener(view: View) {
+        view.setOnClickListener {
             when (type) {
                 AndesCheckboxType.ERROR -> {
                     type = AndesCheckboxType.IDLE

--- a/components/src/main/res/textfield/layout/andes_layout_checkbox.xml
+++ b/components/src/main/res/textfield/layout/andes_layout_checkbox.xml
@@ -5,7 +5,9 @@
     xmlns:tools="http://schemas.android.com/tools"
     android:id="@+id/andes_checkbox_container"
     android:layout_width="wrap_content"
-    android:layout_height="wrap_content">
+    android:layout_height="wrap_content"
+    android:focusable="true"
+    android:clickable="true">
 
     <FrameLayout
         android:id="@+id/containerLeftCheckbox"


### PR DESCRIPTION
### Thanks for starting a pull request on Andes UI!

## Useful links
- [Contributing](https://github.com/mercadolibre/fury_andesui-android/blob/develop/CONTRIBUTING.md) has more information and tips for a great pull request. This will give you a nice introduction about how to contribute with Andes.
- [Wiki](https://github.com/mercadolibre/fury_andesui-android/wiki) has all the info you need to start with Andes. Even I heard there's a video there...

## Motivation
AndesCheckbox needs to be clickable the entire component and not only Checkbox View. This wrong behavior was observed by the UX Team, the entire row should change the state of the checkbox. 

## Description
Set the entire AndesCheckbox component as clickable.

## Frontify component link
The UX team behind Andes keeps all the Andes Components inside the Frontify site. Each component has its own section. Let us know the section of the component you want to modify.

## Change type
This is easy, let us know what this code is about:
- [X] This code includes improvements to an existent component

## Check common errors
Whether you are an Android or iOS developer and if you're still there then we'll give you a present:
https://proandroiddev.com/how-to-maximize-androids-ui-reusability-5-common-mistakes-cb2571216a9f
