### PR TITLE
Added focus listener to EditText inside of AndesTextField

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,11 @@
+# v2.17.0
+## 🚀 Fixes
+- Added Focus listener correctly on EditText of AndesTextField.
+
+# v2.16.0
+## 🚀 Features
+- Added AndesCarousel | Author: [@Constanza Morillo](https://github.com/constanzamorillomeli)
+
 # v2.15.0
 ## 🚀 Features
 - AndesTextFieldCode | Author: [@Jorge Gonzalez](https://github.com/jorGonzalez291292)

--- a/components/src/main/java/com/mercadolibre/android/andesui/textfield/AndesTextfield.kt
+++ b/components/src/main/java/com/mercadolibre/android/andesui/textfield/AndesTextfield.kt
@@ -149,6 +149,14 @@ class AndesTextfield : ConstraintLayout {
             andesTextfieldAttrs = andesTextfieldAttrs.copy(inputType = value)
             setupInputType()
         }
+    /**
+     * Getter and setter for the textComponent onFocusChangeListener.
+     */
+    var textComponentFocusChangedListener: OnFocusChangeListener?
+        get() = textComponent.onFocusChangeListener
+        set(value) {
+            textComponent.onFocusChangeListener = value
+        }
 
     /**
      * Getter and setter for the [textWatcher].
@@ -668,6 +676,16 @@ class AndesTextfield : ConstraintLayout {
 
     fun requestFocusOnTextField() {
         textComponent.requestFocus()
+    }
+
+    /**.___
+     * Register a callback to be invoked when focus of this view changed.
+     *
+     * @param listener The callback that will run.
+    __.*/
+    override fun setOnFocusChangeListener(listener: OnFocusChangeListener?) {
+        super.setOnFocusChangeListener(listener)
+        textComponentFocusChangedListener = listener
     }
 
     /**

--- a/components/src/test/java/com/mercadolibre/android/andesui/textfield/AndesTextfieldTest.kt
+++ b/components/src/test/java/com/mercadolibre/android/andesui/textfield/AndesTextfieldTest.kt
@@ -61,6 +61,18 @@ class AndesTextfieldTest {
     }
 
     @Test
+    fun `textfield with textComponentFocusChangedListener`() {
+        val focusListener = View.OnFocusChangeListener { _, _ -> }
+        textfield.onFocusChangeListener = focusListener
+        assertNotNull(textfield.textComponentFocusChangedListener)
+    }
+
+    @Test
+    fun `textfield without textComponentFocusChangedListener`() {
+        assertNull(textfield.textComponentFocusChangedListener)
+    }
+
+    @Test
     fun `set prefix`() {
         textfield.setPrefix("prefix")
         assertEquals(textfield.leftContent, AndesTextfieldLeftContent.PREFIX)

--- a/demoapp/src/main/res/raw/andesui_demoapp_changelog.md
+++ b/demoapp/src/main/res/raw/andesui_demoapp_changelog.md
@@ -1,3 +1,11 @@
+# v2.17.0
+## 🚀 Fixes
+- Added Focus listener correctly on EditText of AndesTextField.
+
+# v2.16.0
+## 🚀 Features
+- Added AndesCarousel | Author: [@Constanza Morillo](https://github.com/constanzamorillomeli)
+
 # v2.15.0
 ## 🚀 Features
 - AndesTextFieldCode | Author: [@Jorge Gonzalez](https://github.com/jorGonzalez291292)

--- a/gradle.properties
+++ b/gradle.properties
@@ -39,7 +39,7 @@ libraryGroupId=com.mercadolibre.android.andesui
 # IMPORTANT: We're using http://semver.org/ for all Android projects, please remember to follow this convention.
 # IMPORTANT: The version will be THE SAME for all modules.
 # For libraryVersion do NOT add a qualifier to this version like LOCAL/EXPERIMENTAL (it'll be added automatically!)
-libraryVersion=2.15.0
+libraryVersion=2.17.0
 
 ##################################################################################
 # Project setup


### PR DESCRIPTION
### Thanks for starting a pull request on Andes UI!

## Useful links
- [Contributing](https://github.com/mercadolibre/fury_andesui-android/blob/develop/CONTRIBUTING.md) has more information and tips for a great pull request. This will give you a nice introduction about how to contribute with Andes.
- [Wiki](https://github.com/mercadolibre/fury_andesui-android/wiki) has all the info you need to start with Andes. Even I heard there's a video there...

## Description
Se agrega FocusChangedListener al EditText de AndesTextField

## Affected component
AndesTextField

## Frontify component link
The UX team behind Andes keeps all the Andes Components inside the Frontify site. Each component has its own section. Let us know the section of the component you want to modify.

## Checks
Are you sure you followed all those steps? In such case, let's say with me "I solemnly declare that ...":
- [ ] I have coded an example inside the Demo App,
- [x] I have added proper tests,
- [ ] I have modified the [Changelog](https://github.com/mercadolibre/fury_andesui-android/blob/develop/CHANGELOG.md) file,
- [ ] I have updated GitHub wiki,
- [ ] I have the explicit approval of one or more members of the UX Team,
- [ ] I have updated the version in gradle.properties file.

## Change type
This is easy, let us know what this code is about:
- [ ] This code adds a new component
- [x] This code includes improvements to an existent component
- [ ] This code improves or modifies ONLY the Demo App.

## Check common errors
Whether you are an Android or iOS developer and if you're still there then we'll give you a present:
https://proandroiddev.com/how-to-maximize-androids-ui-reusability-5-common-mistakes-cb2571216a9f
