### PR TITLE
AndesTag Left content default color change

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ## 🚀 Fixes
 - Added Focus listener correctly on EditText of AndesTextField.
+- AndesTagChoice left content default color change. | Authors: [@ArnaldoIbanez](https://github.com/ArnaldoIbanez)
 
 # v2.16.0
 ## 🚀 Features

--- a/components/src/main/java/com/mercadolibre/android/andesui/tag/choice/AndesTagChoiceStateInterface.kt
+++ b/components/src/main/java/com/mercadolibre/android/andesui/tag/choice/AndesTagChoiceStateInterface.kt
@@ -40,7 +40,7 @@ internal class AndesChoiceIdleState : AndesTagChoiceStateInterface {
     override fun borderColor() = R.color.andes_gray_250.toAndesColor()
     override fun textColor() = R.color.andes_gray_800_solid.toAndesColor()
     override fun rightContentColor() = R.color.andes_gray_450_solid.toAndesColor()
-    override fun leftContentColor() = R.color.andes_gray_450_solid.toAndesColor()
+    override fun leftContentColor() = R.color.andes_gray_800.toAndesColor()
 }
 
 internal class AndesChoiceSelectedState : AndesTagChoiceStateInterface {


### PR DESCRIPTION
### Thanks for starting a pull request on Andes UI!

## Useful links
- [Contributing](https://github.com/mercadolibre/fury_andesui-android/blob/develop/CONTRIBUTING.md) has more information and tips for a great pull request. This will give you a nice introduction about how to contribute with Andes.
- [Wiki](https://github.com/mercadolibre/fury_andesui-android/wiki) has all the info you need to start with Andes. Even I heard there's a video there...

## Motivation
Tell us why you are here and why you took time to develop new code for our beloved lib.

## Description

Mediante este  PR se pretende cambiar a pedido de UX, el color default que se implemente en los componentes de Left Content para TagChoice a #CC000000

## Affected component
Is highly probable that this new code directly affects one (or more?) components inside this lib. Tell us who they are!

## Frontify component link
The UX team behind Andes keeps all the Andes Components inside the Frontify site. Each component has its own section. Let us know the section of the component you want to modify.

## Screenshots
This is a UI library, delight us with some stunning images.


## Checks
Are you sure you followed all those steps? In such case, let's say with me "I solemnly declare that ...":
- [x] I have coded an example inside the Demo App,
- [ ] I have added proper tests,
- [x] I have modified the [Changelog](https://github.com/mercadolibre/fury_andesui-android/blob/develop/CHANGELOG.md) file,
- [ ] I have updated GitHub wiki,
- [ ] I have the explicit approval of one or more members of the UX Team,
- [ ] I have updated the version in gradle.properties file.

## Change type
This is easy, let us know what this code is about:
- [ ] This code adds a new component
- [ ] This code includes improvements to an existent component
- [ ] This code improves or modifies ONLY the Demo App.

## Check common errors
Whether you are an Android or iOS developer and if you're still there then we'll give you a present:
https://proandroiddev.com/how-to-maximize-androids-ui-reusability-5-common-mistakes-cb2571216a9f

| Antes del cambio | Después del cambio |
| ------------- | ------------- |
|  <img src="https://user-images.githubusercontent.com/63241844/100269671-a8ff2e00-2f35-11eb-9cfe-13bc7a152567.png" width=300> | <img src="https://user-images.githubusercontent.com/63241844/100269705-b5838680-2f35-11eb-89e0-9f8e11f35fbe.png" width=300>  |