### PR TITLE
Fix the size of the right and left componente of text

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# v3.1.1
+## 🚀 Fixes
+- Fix the size of the right and left componente of text
+
 # v3.1.0
 ## 🚀 Features
 - AndesList | Author: [@snti](https://github.com/snti)

--- a/components/src/main/java/com/mercadolibre/android/andesui/textfield/content/AndesTextfieldContentInterface.kt
+++ b/components/src/main/java/com/mercadolibre/android/andesui/textfield/content/AndesTextfieldContentInterface.kt
@@ -40,7 +40,7 @@ internal object AndesSuffixTextfieldContent : AndesTextfieldContentInterface() {
         suffix.setTextColor(R.color.andes_gray_450.toColor(context))
         suffix.text = context.getString(R.string.andes_suffix_hint)
         suffix.typeface = context.getFontOrDefault(R.font.andes_font_regular)
-        suffix.setTextSize(TypedValue.COMPLEX_UNIT_SP, context.resources.getDimension(R.dimen.andes_textfield_edittext_textSize))
+        suffix.setTextSize(TypedValue.COMPLEX_UNIT_PX, context.resources.getDimension(R.dimen.andes_textfield_edittext_textSize))
         return suffix
     }
 }
@@ -55,7 +55,7 @@ internal object AndesPrefixTextfieldContent : AndesTextfieldContentInterface() {
         prefix.setTextColor(R.color.andes_gray_450.toColor(context))
         prefix.text = context.getString(R.string.andes_prefix_hint)
         prefix.typeface = context.getFontOrDefault(R.font.andes_font_regular)
-        prefix.setTextSize(TypedValue.COMPLEX_UNIT_SP, context.resources.getDimension(R.dimen.andes_textfield_edittext_textSize))
+        prefix.setTextSize(TypedValue.COMPLEX_UNIT_PX, context.resources.getDimension(R.dimen.andes_textfield_edittext_textSize))
         return prefix
     }
 }

--- a/demoapp/src/main/res/raw/andesui_demoapp_changelog.md
+++ b/demoapp/src/main/res/raw/andesui_demoapp_changelog.md
@@ -1,3 +1,7 @@
+# v3.1.1
+## 🚀 Fixes
+- Fix the size of the right and left componente of text
+
 # v3.1.0
 ## 🚀 Features
 - AndesList | Author: [@snti](https://github.com/snti)

--- a/gradle.properties
+++ b/gradle.properties
@@ -38,7 +38,7 @@ libraryGroupId=com.mercadolibre.android.andesui
 # IMPORTANT: We're using http://semver.org/ for all Android projects, please remember to follow this convention.
 # IMPORTANT: The version will be THE SAME for all modules.
 # For libraryVersion do NOT add a qualifier to this version like LOCAL/EXPERIMENTAL (it'll be added automatically!)
-libraryVersion=3.1.0
+libraryVersion=3.1.1
 
 ##################################################################################
 # Project setup


### PR DESCRIPTION
### Thanks for starting a pull request on Andes UI!

## Description
Fix the size of the right and left componente of text

## Affected component
TextField

## Screenshots
![Captura de Pantalla 2020-12-14 a la(s) 15 09 59](https://user-images.githubusercontent.com/16910904/102118466-7eaadd00-3e1e-11eb-961a-dfe6d56ae0b4.png)



## Checks
Are you sure you followed all those steps? In such case, let's say with me "I solemnly declare that ...":
- [ ] I have coded an example inside the Demo App,
- [ ] I have added proper tests,
- [X] I have modified the [Changelog](https://github.com/mercadolibre/fury_andesui-android/blob/develop/CHANGELOG.md) file,
- [ ] I have updated GitHub wiki,
- [ ] I have the explicit approval of one or more members of the UX Team,
- [X] I have updated the version in gradle.properties file.

## Change type
This is easy, let us know what this code is about:
- [ ] This code adds a new component
- [X] This code includes improvements to an existent component
- [ ] This code improves or modifies ONLY the Demo App.

## Check common errors
Whether you are an Android or iOS developer and if you're still there then we'll give you a present:
https://proandroiddev.com/how-to-maximize-androids-ui-reusability-5-common-mistakes-cb2571216a9f
