### PR TITLE
fix bodypadding

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,10 +1,9 @@
 # Pending definition
-## 🚀 Features
-- Added new icons for "Online Payments" and "QR"
-
-# v3.3.1
 ## 🛠 Fixes
 - Fix bodyPadding on CardComponent when padding is none from XML | Author: [@ariel-ramirez](https://github.com/ariel-ramirez)
+
+## 🚀 Features
+- Added new icons for "Online Payments" and "QR"
 
 # v3.3.0
 ## 🛠 Fixes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 ## 🚀 Features
 - Added new icons for "Online Payments" and "QR"
 
+# v3.3.1
+## 🛠 Fixes
+- Fix bodyPadding on CardComponent when padding is none from XML | Author: [@ariel-ramirez](https://github.com/ariel-ramirez)
+
 # v3.3.0
 ## 🛠 Fixes
 - Fix the size of the calendar api level < 21

--- a/components/src/main/java/com/mercadolibre/android/andesui/card/AndesCard.kt
+++ b/components/src/main/java/com/mercadolibre/android/andesui/card/AndesCard.kt
@@ -45,6 +45,7 @@ class AndesCard : CardView {
         get() = andesCardAttrs.andesCardPadding
         set(value) {
             andesCardAttrs = andesCardAttrs.copy(andesCardPadding = value)
+            andesCardAttrs = andesCardAttrs.copy(andesCardBodyPadding = viewComponentWithoutBodyPadding(value))
             val config = createConfig()
             setupBackgroundComponent(config)
             setupTitleComponent(config)
@@ -344,7 +345,7 @@ class AndesCard : CardView {
      */
     private fun viewComponentWithoutBodyPadding(padding: AndesCardPadding): AndesCardBodyPadding {
         return when(padding) {
-            AndesCardPadding.NONE -> AndesCardBodyPadding.SMALL
+            AndesCardPadding.NONE -> AndesCardBodyPadding.NONE
             AndesCardPadding.SMALL -> AndesCardBodyPadding.SMALL
             AndesCardPadding.MEDIUM -> AndesCardBodyPadding.MEDIUM
             AndesCardPadding.LARGE -> AndesCardBodyPadding.LARGE

--- a/components/src/main/java/com/mercadolibre/android/andesui/card/AndesCard.kt
+++ b/components/src/main/java/com/mercadolibre/android/andesui/card/AndesCard.kt
@@ -340,7 +340,6 @@ class AndesCard : CardView {
     }
 
     /**
-     * Keeps in SMALL bodyPadding when padding property is set at NONE.
      * Emulates the behavior for develops that do not support or do not set bodyPadding property.
      */
     private fun viewComponentWithoutBodyPadding(padding: AndesCardPadding): AndesCardBodyPadding {

--- a/components/src/main/java/com/mercadolibre/android/andesui/card/AndesCard.kt
+++ b/components/src/main/java/com/mercadolibre/android/andesui/card/AndesCard.kt
@@ -44,8 +44,7 @@ class AndesCard : CardView {
     var padding: AndesCardPadding
         get() = andesCardAttrs.andesCardPadding
         set(value) {
-            andesCardAttrs = andesCardAttrs.copy(andesCardPadding = value)
-            andesCardAttrs = andesCardAttrs.copy(andesCardBodyPadding = viewComponentWithoutBodyPadding(value))
+            andesCardAttrs = andesCardAttrs.copy(andesCardPadding = value, andesCardBodyPadding = viewComponentWithoutBodyPadding(value))
             val config = createConfig()
             setupBackgroundComponent(config)
             setupTitleComponent(config)

--- a/components/src/test/java/com/mercadolibre/android/andesui/card/AndesCardTest.kt
+++ b/components/src/test/java/com/mercadolibre/android/andesui/card/AndesCardTest.kt
@@ -190,6 +190,38 @@ class AndesCardTest {
     }
 
     @Test
+    fun `Padding small and BodyPadding none`() {
+        attrs = AndesCardAttrs(
+                View(context),
+                AndesCardType.NONE,
+                AndesCardPadding.SMALL,
+                AndesCardBodyPadding.NONE,
+                AndesCardStyle.OUTLINE,
+                "Title",
+                AndesCardHierarchy.SECONDARY
+        )
+        val config = configFactory.create(context, attrs)
+        assertEquals(config.titlePadding, context.resources.getDimension(R.dimen.andes_card_padding_small).toInt())
+        assertEquals(config.bodyPadding.bodyPadding.bodyPaddingSize(context), context.resources.getDimension(R.dimen.andes_card_padding_none).toInt())
+    }
+
+    @Test
+    fun `Padding and BodyPadding none`() {
+        attrs = AndesCardAttrs(
+                View(context),
+                AndesCardType.NONE,
+                AndesCardPadding.NONE,
+                AndesCardBodyPadding.NONE,
+                AndesCardStyle.OUTLINE,
+                "Title",
+                AndesCardHierarchy.SECONDARY
+        )
+        val config = configFactory.create(context, attrs)
+        assertEquals(config.titlePadding, context.resources.getDimension(R.dimen.andes_card_padding_small).toInt())
+        assertEquals(config.bodyPadding.bodyPadding.bodyPaddingSize(context), context.resources.getDimension(R.dimen.andes_card_padding_none).toInt())
+    }
+
+    @Test
     fun `Body none then body padding small`() {
         val andesCard = AndesCard(context, view, AndesCardType.NONE, AndesCardPadding.NONE, "title", AndesCardStyle.ELEVATED, AndesCardHierarchy.PRIMARY)
         andesCard.bodyPadding = AndesCardBodyPadding.SMALL

--- a/gradle.properties
+++ b/gradle.properties
@@ -38,7 +38,7 @@ libraryGroupId=com.mercadolibre.android.andesui
 # IMPORTANT: We're using http://semver.org/ for all Android projects, please remember to follow this convention.
 # IMPORTANT: The version will be THE SAME for all modules.
 # For libraryVersion do NOT add a qualifier to this version like LOCAL/EXPERIMENTAL (it'll be added automatically!)
-libraryVersion=3.3.0
+libraryVersion=3.3.1
 
 ##################################################################################
 # Project setup


### PR DESCRIPTION
### Thanks for starting a pull request on Andes UI!

## Useful links
- [Contributing](https://github.com/mercadolibre/fury_andesui-android/blob/develop/CONTRIBUTING.md) has more information and tips for a great pull request. This will give you a nice introduction about how to contribute with Andes.
- [Wiki](https://github.com/mercadolibre/fury_andesui-android/wiki) has all the info you need to start with Andes. Even I heard there's a video there...

## Motivation
Fix aplicado al cambio del siguiente PR: [PR del cambio original](https://github.com/mercadolibre/fury_andesui-android/pull/206)
RFC: [documento RFC](https://docs.google.com/document/d/1Nc22biT3CclP_hmpG1JC3uUc_58NZx612BdlYsCq2xE/edit#heading=h.ixm8d2k39d9a)

## Description
Se corrige el seteo de la property **bodyPadding** cuando este tiene la property **padding** seteada directamente del XML en **NONE**
¿Qué sucedía? Al establecer padding: NONE desde el layout, la propiedad bodyPadding no copiaba el valor correcto para guardar en la config. No sucede lo mismo si se establece como valor SMALL o superiores; como así tampoco si se establece el valor **bodyPadding** explícitamente por código.
En este PR se anula cualquier valor inyectado desde el XML para **bodyPadding**, pisándolo con el valor obtenido en la propiedad **padding**, asegurando retrocompatibilidad.

## Affected component
AndesCard

## Frontify component link
The UX team behind Andes keeps all the Andes Components inside the Frontify site. Each component has its own section. Let us know the section of the component you want to modify.

## Screenshots
TestApp | Project example XML | Project example Code | Project example Activity
------------ | ------------- | ------------- | -------------
![andes_test_App](https://user-images.githubusercontent.com/46376193/104015797-ec36f880-5193-11eb-949d-36bf5660166d.gif) | ![image](https://user-images.githubusercontent.com/46376193/104015857-01138c00-5194-11eb-9bab-010780ab9886.png) | ![image](https://user-images.githubusercontent.com/46376193/104015904-138dc580-5194-11eb-972e-0403d162d9a2.png) | ![image](https://user-images.githubusercontent.com/46376193/104015940-230d0e80-5194-11eb-99b3-72cdce2ba7ac.png)

## Checks
Are you sure you followed all those steps? In such case, let's say with me "I solemnly declare that ...":
- [x] I have coded an example inside the Demo App,
- [x] I have added proper tests,
- [x] I have modified the [Changelog](https://github.com/mercadolibre/fury_andesui-android/blob/develop/CHANGELOG.md) file,
- [ ] I have updated GitHub wiki,
- [ ] I have the explicit approval of one or more members of the UX Team,
- [x] I have updated the version in gradle.properties file.

## Change type
This is easy, let us know what this code is about:
- [ ] This code adds a new component
- [x] This code includes improvements to an existent component
- [ ] This code improves or modifies ONLY the Demo App.

## Check common errors
Whether you are an Android or iOS developer and if you're still there then we'll give you a present:
https://proandroiddev.com/how-to-maximize-androids-ui-reusability-5-common-mistakes-cb2571216a9f
