### PR TITLE
AndesButton with drawable support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# v3.6.0
+### 🚀 Feature
+- AndesButton With Drawable support | Authors [a0zamora](https://github.com/a0zamora)
+
 # v3.5.1
 ## 🛠 Fixes
 - Datepicker accent color

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,17 +1,13 @@
 # v3.6.0
-### 🚀 Feature
+## 🚀 Feature
 - AndesButton With Drawable support | Authors [a0zamora](https://github.com/a0zamora)
 
-# v3.5.1
 ## 🛠 Fixes
 - Datepicker accent color
 
 # v3.5.0
-### 🚀 Feature
+## 🚀 Feature
 - AndesMessage With Thumbnnail | Authors [a0zamora](https://github.com/a0zamora)
-
-### ⚙️ Other
-- Disable bot for issues | Authors [joalonspint](https://github.com/joalonsopint)
 
 # v3.4.0
 ## 🚀 Features

--- a/components/src/main/java/com/mercadolibre/android/andesui/button/AndesButton.kt
+++ b/components/src/main/java/com/mercadolibre/android/andesui/button/AndesButton.kt
@@ -25,7 +25,11 @@ import com.mercadolibre.android.andesui.button.factory.AndesButtonAttrs
 import com.mercadolibre.android.andesui.button.factory.AndesButtonAttrsParser
 import com.mercadolibre.android.andesui.button.factory.AndesButtonConfiguration
 import com.mercadolibre.android.andesui.button.factory.AndesButtonConfigurationFactory
-import com.mercadolibre.android.andesui.button.hierarchy.*
+import com.mercadolibre.android.andesui.button.hierarchy.AndesButtonHierarchy
+import com.mercadolibre.android.andesui.button.hierarchy.AndesButtonIcon
+import com.mercadolibre.android.andesui.button.hierarchy.AndesButtonIconOrientation
+import com.mercadolibre.android.andesui.button.hierarchy.BackgroundColorConfig
+import com.mercadolibre.android.andesui.button.hierarchy.getConfiguredBackground
 import com.mercadolibre.android.andesui.button.size.AndesButtonSize
 import com.mercadolibre.android.andesui.progress.AndesProgressIndicatorIndeterminate
 import com.mercadolibre.android.andesui.progress.size.AndesProgressSize

--- a/components/src/main/java/com/mercadolibre/android/andesui/button/AndesButton.kt
+++ b/components/src/main/java/com/mercadolibre/android/andesui/button/AndesButton.kt
@@ -25,7 +25,10 @@ import com.mercadolibre.android.andesui.button.factory.AndesButtonAttrs
 import com.mercadolibre.android.andesui.button.factory.AndesButtonAttrsParser
 import com.mercadolibre.android.andesui.button.factory.AndesButtonConfiguration
 import com.mercadolibre.android.andesui.button.factory.AndesButtonConfigurationFactory
-import com.mercadolibre.android.andesui.button.hierarchy.*
+import com.mercadolibre.android.andesui.button.hierarchy.AndesButtonHierarchy
+import com.mercadolibre.android.andesui.button.hierarchy.AndesButtonIcon
+import com.mercadolibre.android.andesui.button.hierarchy.AndesButtonIconOrientation
+import com.mercadolibre.android.andesui.button.hierarchy.BackgroundColorConfig
 import com.mercadolibre.android.andesui.button.size.AndesButtonSize
 import com.mercadolibre.android.andesui.progress.AndesProgressIndicatorIndeterminate
 import com.mercadolibre.android.andesui.progress.size.AndesProgressSize

--- a/components/src/main/java/com/mercadolibre/android/andesui/button/AndesButton.kt
+++ b/components/src/main/java/com/mercadolibre/android/andesui/button/AndesButton.kt
@@ -25,10 +25,7 @@ import com.mercadolibre.android.andesui.button.factory.AndesButtonAttrs
 import com.mercadolibre.android.andesui.button.factory.AndesButtonAttrsParser
 import com.mercadolibre.android.andesui.button.factory.AndesButtonConfiguration
 import com.mercadolibre.android.andesui.button.factory.AndesButtonConfigurationFactory
-import com.mercadolibre.android.andesui.button.hierarchy.AndesButtonHierarchy
-import com.mercadolibre.android.andesui.button.hierarchy.AndesButtonIcon
-import com.mercadolibre.android.andesui.button.hierarchy.AndesButtonIconOrientation
-import com.mercadolibre.android.andesui.button.hierarchy.BackgroundColorConfig
+import com.mercadolibre.android.andesui.button.hierarchy.*
 import com.mercadolibre.android.andesui.button.size.AndesButtonSize
 import com.mercadolibre.android.andesui.progress.AndesProgressIndicatorIndeterminate
 import com.mercadolibre.android.andesui.progress.size.AndesProgressSize

--- a/components/src/main/java/com/mercadolibre/android/andesui/button/AndesButton.kt
+++ b/components/src/main/java/com/mercadolibre/android/andesui/button/AndesButton.kt
@@ -523,6 +523,11 @@ class AndesButton : ConstraintLayout {
         }
     }
 
+    /**
+     * sets an icon to right or left, depending on the orientation
+     * @param drawable the drawable that is going to be shown
+     * @param orientation AndesButtonIconOrientation LEFT|RIGHT
+     */
     fun setIconDrawable(drawable: Drawable, orientation: AndesButtonIconOrientation) {
         andesButtonAttrs = when (orientation) {
             AndesButtonIconOrientation.LEFT -> andesButtonAttrs.copy(andesButtonLeftDrawable = drawable)

--- a/components/src/main/java/com/mercadolibre/android/andesui/button/AndesButton.kt
+++ b/components/src/main/java/com/mercadolibre/android/andesui/button/AndesButton.kt
@@ -2,18 +2,19 @@ package com.mercadolibre.android.andesui.button
 
 import android.content.Context
 import android.graphics.drawable.Animatable
+import android.graphics.drawable.Drawable
 import android.os.Build
 import android.os.Bundle
 import android.os.Parcelable
-import androidx.annotation.Nullable
-import androidx.constraintlayout.widget.ConstraintLayout
-import androidx.constraintlayout.widget.ConstraintSet
-import androidx.appcompat.widget.AppCompatButton
 import android.text.TextUtils
 import android.util.AttributeSet
 import android.util.TypedValue
 import android.view.View
 import android.widget.TextView
+import androidx.annotation.Nullable
+import androidx.appcompat.widget.AppCompatButton
+import androidx.constraintlayout.widget.ConstraintLayout
+import androidx.constraintlayout.widget.ConstraintSet
 import com.facebook.drawee.backends.pipeline.PipelineDraweeControllerBuilder
 import com.facebook.drawee.controller.BaseControllerListener
 import com.facebook.drawee.controller.ControllerListener
@@ -24,10 +25,7 @@ import com.mercadolibre.android.andesui.button.factory.AndesButtonAttrs
 import com.mercadolibre.android.andesui.button.factory.AndesButtonAttrsParser
 import com.mercadolibre.android.andesui.button.factory.AndesButtonConfiguration
 import com.mercadolibre.android.andesui.button.factory.AndesButtonConfigurationFactory
-import com.mercadolibre.android.andesui.button.hierarchy.AndesButtonHierarchy
-import com.mercadolibre.android.andesui.button.hierarchy.AndesButtonIcon
-import com.mercadolibre.android.andesui.button.hierarchy.BackgroundColorConfig
-import com.mercadolibre.android.andesui.button.hierarchy.getConfiguredBackground
+import com.mercadolibre.android.andesui.button.hierarchy.*
 import com.mercadolibre.android.andesui.button.size.AndesButtonSize
 import com.mercadolibre.android.andesui.progress.AndesProgressIndicatorIndeterminate
 import com.mercadolibre.android.andesui.progress.size.AndesProgressSize
@@ -153,7 +151,7 @@ class AndesButton : ConstraintLayout {
         buttonIcon: AndesButtonIcon? = ICON_DEFAULT,
         buttonText: String? = TEXT_DEFAULT
     ) :
-            super(context) {
+        super(context) {
         initAttrs(buttonSize, buttonHierarchy, buttonIcon, buttonText)
     }
 
@@ -200,10 +198,10 @@ class AndesButton : ConstraintLayout {
         text: String?
     ) {
         andesButtonAttrs = AndesButtonAttrs(buttonHierarchy,
-                buttonSize,
-                buttonIcon?.leftIcon,
-                buttonIcon?.rightIcon,
-                text)
+            buttonSize,
+            buttonIcon?.leftIcon,
+            buttonIcon?.rightIcon,
+            text)
         setupComponents(createConfig())
     }
 
@@ -255,11 +253,11 @@ class AndesButton : ConstraintLayout {
         val set = ConstraintSet()
         set.clone(this)
         set.createHorizontalChain(
-                ConstraintSet.PARENT_ID, ConstraintSet.LEFT,
-                ConstraintSet.PARENT_ID, ConstraintSet.RIGHT,
-                intArrayOf(leftIconComponent.id, textComponent.id, rightIconComponent.id),
-                null,
-                ConstraintSet.CHAIN_PACKED
+            ConstraintSet.PARENT_ID, ConstraintSet.LEFT,
+            ConstraintSet.PARENT_ID, ConstraintSet.RIGHT,
+            intArrayOf(leftIconComponent.id, textComponent.id, rightIconComponent.id),
+            null,
+            ConstraintSet.CHAIN_PACKED
         )
 
         set.centerVertically(leftIconComponent.id, ConstraintSet.PARENT_ID)
@@ -439,8 +437,8 @@ class AndesButton : ConstraintLayout {
 
     internal fun changeBackgroundColor(backgroundColorConfig: BackgroundColorConfig) {
         background = getConfiguredBackground(context,
-                context.resources.getDimension(R.dimen.andes_button_border_radius_medium),
-                backgroundColorConfig)
+            context.resources.getDimension(R.dimen.andes_button_border_radius_medium),
+            backgroundColorConfig)
     }
 
     /**
@@ -477,7 +475,7 @@ class AndesButton : ConstraintLayout {
         if (!leftIconPosition) {
             icon = rightIconComponent
             andesButtonAttrs = andesButtonAttrs.copy(andesButtonLeftIconPath = null,
-                    andesButtonRightIconPath = CUSTOM_ICON_DEFAULT)
+                andesButtonRightIconPath = CUSTOM_ICON_DEFAULT)
         }
 
         val listener: ControllerListener<ImageInfo> = object : BaseControllerListener<ImageInfo>() {
@@ -491,8 +489,8 @@ class AndesButton : ConstraintLayout {
         }
 
         val controller = pipelineDraweeControllerBuilder
-                .setControllerListener(listener)
-                .build()
+            .setControllerListener(listener)
+            .build()
 
         icon.controller = controller
         icon.visibility = View.VISIBLE
@@ -517,6 +515,18 @@ class AndesButton : ConstraintLayout {
         }
 
         createConfig().also {
+            updateComponentsAlignment(it)
+        }
+    }
+
+    fun setIconDrawable(drawable: Drawable, orientation: AndesButtonIconOrientation) {
+        andesButtonAttrs = when (orientation) {
+            AndesButtonIconOrientation.LEFT -> andesButtonAttrs.copy(andesButtonLeftDrawable = drawable)
+            AndesButtonIconOrientation.RIGHT -> andesButtonAttrs.copy(andesButtonRightDrawable = drawable)
+        }
+
+        createConfig().also {
+            updateDynamicComponents(it)
             updateComponentsAlignment(it)
         }
     }

--- a/components/src/main/java/com/mercadolibre/android/andesui/button/factory/AndesButtonAttrsParser.kt
+++ b/components/src/main/java/com/mercadolibre/android/andesui/button/factory/AndesButtonAttrsParser.kt
@@ -1,6 +1,7 @@
 package com.mercadolibre.android.andesui.button.factory
 
 import android.content.Context
+import android.graphics.drawable.Drawable
 import android.util.AttributeSet
 import com.mercadolibre.android.andesui.R
 import com.mercadolibre.android.andesui.button.hierarchy.AndesButtonHierarchy
@@ -16,7 +17,9 @@ internal data class AndesButtonAttrs(
     val andesButtonRightIconPath: String?,
     val andesButtonText: String?,
     val andesButtonEnabled: Boolean = true,
-    val andesButtonIsLoading: Boolean = false
+    val andesButtonIsLoading: Boolean = false,
+    val andesButtonLeftDrawable: Drawable? = null,
+    val andesButtonRightDrawable: Drawable? = null
 )
 
 /**

--- a/components/src/main/java/com/mercadolibre/android/andesui/button/factory/AndesButtonConfigurationFactory.kt
+++ b/components/src/main/java/com/mercadolibre/android/andesui/button/factory/AndesButtonConfigurationFactory.kt
@@ -2,10 +2,8 @@ package com.mercadolibre.android.andesui.button.factory
 
 import android.content.Context
 import android.content.res.ColorStateList
-import android.content.res.TypedArray
 import android.graphics.Typeface
 import android.graphics.drawable.Drawable
-import com.mercadolibre.android.andesui.R
 import com.mercadolibre.android.andesui.button.AndesButton
 import com.mercadolibre.android.andesui.button.factory.AndesButtonConfigurationFactory.create
 import com.mercadolibre.android.andesui.button.hierarchy.AndesButtonHierarchy
@@ -80,20 +78,22 @@ internal object AndesButtonConfigurationFactory {
         val size = andesButtonAttrs.andesButtonSize.size
 
         return AndesButtonConfiguration(
-                background = resolveBackground(hierarchy, size, context),
-                text = andesButtonAttrs.andesButtonText,
-                textColor = resolveTextColor(hierarchy, context),
-                textSize = resolveTextSize(size, context),
-                margin = resolveMargin(size, andesButtonAttrs.andesButtonLeftIconPath,
-                        andesButtonAttrs.andesButtonRightIconPath, context),
-                height = resolveHeight(size, context),
-                typeface = resolveTypeface(hierarchy, context),
-                iconConfig = resolveIconConfig(size, hierarchy,
-                        andesButtonAttrs.andesButtonLeftIconPath,
-                        andesButtonAttrs.andesButtonRightIconPath, context),
-                enabled = andesButtonAttrs.andesButtonEnabled,
-                lateralPadding = resolveLateralPadding(size, context),
-                isLoading = andesButtonAttrs.andesButtonIsLoading
+            background = resolveBackground(hierarchy, size, context),
+            text = andesButtonAttrs.andesButtonText,
+            textColor = resolveTextColor(hierarchy, context),
+            textSize = resolveTextSize(size, context),
+            margin = resolveMargin(size, andesButtonAttrs.andesButtonLeftIconPath,
+                andesButtonAttrs.andesButtonRightIconPath, andesButtonAttrs.andesButtonLeftDrawable,
+                andesButtonAttrs.andesButtonRightDrawable, context),
+            height = resolveHeight(size, context),
+            typeface = resolveTypeface(hierarchy, context),
+            iconConfig = resolveIconConfig(size, hierarchy,
+                andesButtonAttrs.andesButtonLeftIconPath,
+                andesButtonAttrs.andesButtonRightIconPath, andesButtonAttrs.andesButtonLeftDrawable,
+                andesButtonAttrs.andesButtonRightDrawable, context),
+            enabled = andesButtonAttrs.andesButtonEnabled,
+            lateralPadding = resolveLateralPadding(size, context),
+            isLoading = andesButtonAttrs.andesButtonIsLoading
         )
     }
 
@@ -109,27 +109,31 @@ internal object AndesButtonConfigurationFactory {
      * @param andesButtonIcon has the necessary info about the icon to draw.
      * @return an [AndesButtonConfiguration] that contains all the data that [AndesButton] needs to draw itself properly.
      */
+
+    @Suppress("LongParameterList")
     @Override
     fun create(
         context: Context,
         andesButtonSize: AndesButtonSize,
         andesButtonHierarchy: AndesButtonHierarchy,
-        andesButtonIcon: AndesButtonIcon?
+        andesButtonIcon: AndesButtonIcon?,
+        andesButtonLeftDrawable: Drawable?,
+        andesButtonRightDrawable: Drawable?
     ): AndesButtonConfiguration {
         val size = andesButtonSize.size
         val hierarchy = andesButtonHierarchy.hierarchy
 
         return AndesButtonConfiguration(
-                background = resolveBackground(hierarchy, size, context),
-                textColor = resolveTextColor(hierarchy, context),
-                textSize = resolveTextSize(size, context),
-                margin = resolveMargin(size,
-                        andesButtonIcon?.leftIcon, andesButtonIcon?.rightIcon, context),
-                height = resolveHeight(size, context),
-                typeface = resolveTypeface(hierarchy, context),
-                iconConfig = resolveIconConfig(size,
-                        hierarchy, andesButtonIcon?.leftIcon, andesButtonIcon?.rightIcon, context),
-                lateralPadding = resolveLateralPadding(size, context)
+            background = resolveBackground(hierarchy, size, context),
+            textColor = resolveTextColor(hierarchy, context),
+            textSize = resolveTextSize(size, context),
+            margin = resolveMargin(size,
+                andesButtonIcon?.leftIcon, andesButtonIcon?.rightIcon, andesButtonLeftDrawable, andesButtonRightDrawable, context),
+            height = resolveHeight(size, context),
+            typeface = resolveTypeface(hierarchy, context),
+            iconConfig = resolveIconConfig(size,
+                hierarchy, andesButtonIcon?.leftIcon, andesButtonIcon?.rightIcon, andesButtonLeftDrawable, andesButtonRightDrawable, context),
+            lateralPadding = resolveLateralPadding(size, context)
         )
     }
 
@@ -178,8 +182,10 @@ internal object AndesButtonConfigurationFactory {
         size: AndesButtonSizeInterface,
         leftIconPath: String?,
         rightIconPath: String?,
+        leftDrawable: Drawable?,
+        rightDrawable: Drawable?,
         context: Context
-    ) = AndesButtonMargin(size, leftIconPath, rightIconPath, context)
+    ) = AndesButtonMargin(size, leftIconPath, rightIconPath, context, leftDrawable, rightDrawable)
 
     /**
      * Determines the height of the button from certain parameters that receives.
@@ -188,7 +194,7 @@ internal object AndesButtonConfigurationFactory {
      * @param context needed for accessing some resources.
      */
     private fun resolveHeight(size: AndesButtonSizeInterface, context: Context) =
-            size.height(context)
+        size.height(context)
 
     /**
      * Determines the [Typeface] from certain parameters that receives.
@@ -198,7 +204,7 @@ internal object AndesButtonConfigurationFactory {
      * @param context needed for accessing font resources.
      */
     private fun resolveTypeface(hierarchy: AndesButtonHierarchyInterface, context: Context) =
-            hierarchy.typeface(context)
+        hierarchy.typeface(context)
 
     /**
      * Determines the [IconConfig] from certain parameters that receives.
@@ -220,8 +226,10 @@ internal object AndesButtonConfigurationFactory {
         hierarchy: AndesButtonHierarchyInterface,
         leftIconPath: String?,
         rightIconPath: String?,
+        leftDrawable: Drawable?,
+        rightDrawable: Drawable?,
         context: Context
-    ) = size.iconConfig(hierarchy, leftIconPath, rightIconPath, context)
+    ) = size.iconConfig(hierarchy, leftIconPath, rightIconPath, leftDrawable, rightDrawable, context)
 
     /**
      * Determines the padding of the button.

--- a/components/src/main/java/com/mercadolibre/android/andesui/button/factory/AndesButtonMargin.kt
+++ b/components/src/main/java/com/mercadolibre/android/andesui/button/factory/AndesButtonMargin.kt
@@ -1,6 +1,7 @@
 package com.mercadolibre.android.andesui.button.factory
 
 import android.content.Context
+import android.graphics.drawable.Drawable
 import com.mercadolibre.android.andesui.button.size.AndesButtonSizeInterface
 
 /**
@@ -19,7 +20,9 @@ internal class AndesButtonMargin(
     private val size: AndesButtonSizeInterface,
     private val leftIcon: String?,
     private val rightIcon: String?,
-    private val context: Context
+    private val context: Context,
+    private val leftDrawable: Drawable?,
+    private val rightDrawable: Drawable?
 ) {
 
     var textLeftMargin: Int = 0
@@ -39,8 +42,8 @@ internal class AndesButtonMargin(
         }
     }
 
-    private fun hasLeftIcon() = size.canDisplayIcon() && leftIcon != null
-    private fun hasRightIcon() = size.canDisplayIcon() && rightIcon != null
+    private fun hasLeftIcon() = size.canDisplayIcon() && (leftIcon != null || leftDrawable != null)
+    private fun hasRightIcon() = size.canDisplayIcon() && (rightIcon != null || rightDrawable != null)
 
     private fun configureLeftIconValues() {
         textLeftMargin = 0

--- a/components/src/main/java/com/mercadolibre/android/andesui/button/size/AndesButtonSizeInterface.kt
+++ b/components/src/main/java/com/mercadolibre/android/andesui/button/size/AndesButtonSizeInterface.kt
@@ -175,10 +175,10 @@ internal class AndesLargeButtonSize : AndesButtonSizeInterface {
             rightIcon != null -> {
                 handlePathIcon(context, rightIcon, hierarchy, AndesButtonIconOrientation.RIGHT)
             }
-            leftDrawable != null -> { // Ignoring if rightIcon is also non null: Left icon has higher precedence than right
+            leftDrawable != null -> {
                 handleIcon(context, leftDrawable, hierarchy, AndesButtonIconOrientation.LEFT)
             }
-            rightDrawable != null -> { // Ignoring if rightIcon is also non null: Left icon has higher precedence than right
+            rightDrawable != null -> {
                 handleIcon(context, rightDrawable, hierarchy, AndesButtonIconOrientation.RIGHT)
             }
             else -> {

--- a/components/src/main/java/com/mercadolibre/android/andesui/button/size/AndesButtonSizeInterface.kt
+++ b/components/src/main/java/com/mercadolibre/android/andesui/button/size/AndesButtonSizeInterface.kt
@@ -170,10 +170,10 @@ internal class AndesLargeButtonSize : AndesButtonSizeInterface {
 
         return when {
             leftIcon != null -> { // Ignoring if rightIcon is also non null: Left icon has higher precedence than right
-                handleStringIcon(context, leftIcon, hierarchy, AndesButtonIconOrientation.LEFT)
+                handlePathIcon(context, leftIcon, hierarchy, AndesButtonIconOrientation.LEFT)
             }
             rightIcon != null -> {
-                handleStringIcon(context, rightIcon, hierarchy, AndesButtonIconOrientation.RIGHT)
+                handlePathIcon(context, rightIcon, hierarchy, AndesButtonIconOrientation.RIGHT)
             }
             leftDrawable != null -> { // Ignoring if rightIcon is also non null: Left icon has higher precedence than right
                 handleIcon(context, leftDrawable, hierarchy, AndesButtonIconOrientation.LEFT)
@@ -207,7 +207,7 @@ internal class AndesLargeButtonSize : AndesButtonSizeInterface {
         }
     }
 
-    private fun handleStringIcon(context: Context, leftIcon: String,
+    private fun handlePathIcon(context: Context, leftIcon: String,
         hierarchy: AndesButtonHierarchyInterface, orientation: AndesButtonIconOrientation): IconConfig? {
         val icon = IconProvider(context)
             .loadIcon(leftIcon)

--- a/components/src/test/java/com/mercadolibre/android/andesui/button/AndesButtonSizeTest.kt
+++ b/components/src/test/java/com/mercadolibre/android/andesui/button/AndesButtonSizeTest.kt
@@ -67,7 +67,7 @@ class AndesLargeButtonSizeTest {
 
     @Test
     fun `Large button icon null`() {
-        assertEquals(andesLargeButtonSize.iconConfig(hierarchy, null, null, context), null)
+        assertEquals(andesLargeButtonSize.iconConfig(hierarchy, null, null, null, null, context), null)
     }
 
     @Test
@@ -125,17 +125,17 @@ class AndesMediumButtonSizeTest {
 
     @Test
     fun `Medium button icon null`() {
-        assertNull(andesMediumButtonSize.iconConfig(hierarchy, null, null, context))
+        assertNull(andesMediumButtonSize.iconConfig(hierarchy, null, null, null, null,context))
     }
 
     @Test
     fun `Medium button left icon`() {
-        assertNull(andesMediumButtonSize.iconConfig(hierarchy, ANDES_ICON, null, context))
+        assertNull(andesMediumButtonSize.iconConfig(hierarchy, ANDES_ICON, null, null, null,context))
     }
 
     @Test
     fun `Medium button right icon`() {
-        assertNull(andesMediumButtonSize.iconConfig(hierarchy, null, ANDES_ICON, context))
+        assertNull(andesMediumButtonSize.iconConfig(hierarchy, null, ANDES_ICON, null, null,context))
     }
 }
 
@@ -182,16 +182,16 @@ class AndesSmallButtonSizeTest {
 
     @Test
     fun `Small button icon null`() {
-        assertNull(andesSmallButtonSize.iconConfig(hierarchy, null, null, context))
+        assertNull(andesSmallButtonSize.iconConfig(hierarchy, null, null, null, null,context))
     }
 
     @Test
     fun `Small button left icon`() {
-        assertNull(andesSmallButtonSize.iconConfig(hierarchy, ANDES_ICON, null, context))
+        assertNull(andesSmallButtonSize.iconConfig(hierarchy, ANDES_ICON, null, null, null,context))
     }
 
     @Test
     fun `Small button right icon`() {
-        assertNull(andesSmallButtonSize.iconConfig(hierarchy, null, ANDES_ICON, context))
+        assertNull(andesSmallButtonSize.iconConfig(hierarchy, null, ANDES_ICON, null, null,context))
     }
 }

--- a/components/src/test/java/com/mercadolibre/android/andesui/button/AndesButtonTest.kt
+++ b/components/src/test/java/com/mercadolibre/android/andesui/button/AndesButtonTest.kt
@@ -1,6 +1,8 @@
 package com.mercadolibre.android.andesui.button
 
+import android.graphics.drawable.BitmapDrawable
 import android.os.Build
+import android.view.View
 import androidx.constraintlayout.widget.ConstraintLayout
 import com.facebook.common.logging.FLog
 import com.facebook.drawee.backends.pipeline.Fresco
@@ -8,14 +10,13 @@ import com.facebook.imagepipeline.core.ImagePipelineConfig
 import com.facebook.imagepipeline.listener.RequestListener
 import com.facebook.imagepipeline.listener.RequestLoggingListener
 import com.facebook.soloader.SoLoader
-import com.mercadolibre.android.andesui.BuildConfig
 import com.mercadolibre.android.andesui.button.hierarchy.AndesButtonHierarchy
 import com.mercadolibre.android.andesui.button.hierarchy.AndesButtonIcon
 import com.mercadolibre.android.andesui.button.hierarchy.AndesButtonIconOrientation
 import com.mercadolibre.android.andesui.button.size.AndesButtonSize
+import com.mercadolibre.android.andesui.icons.IconProvider
 import org.assertj.core.api.Assertions.assertThat
-import org.junit.Assert.assertEquals
-import org.junit.Assert.assertNull
+import org.junit.Assert.*
 import org.junit.Before
 import org.junit.BeforeClass
 import org.junit.Test
@@ -113,5 +114,25 @@ class AndesButtonTest {
         assertNull(andesButton.leftIconComponent.drawable)
         assertThat(andesButton.rightIconComponent.drawable).isEqualToComparingOnlyGivenFields(icon)
         assertEquals(andesButton.isLoading, false)
+    }
+
+    @Test
+    fun `Drawable left is visible after set`() {
+        andesButton = AndesButton(context, AndesButtonSize.LARGE, AndesButtonHierarchy.TRANSPARENT, null)
+        assertEquals(andesButton.leftIconComponent.drawable, null)
+        val drawable = IconProvider(context)
+            .loadIcon("andes_ui_placeholder_imagen_24") as BitmapDrawable
+        andesButton.setIconDrawable(drawable, AndesButtonIconOrientation.LEFT)
+        assertEquals(andesButton.leftIconComponent.visibility, View.VISIBLE)
+    }
+
+    @Test
+    fun `Drawable right is visible after set`() {
+        andesButton = AndesButton(context, AndesButtonSize.LARGE, AndesButtonHierarchy.TRANSPARENT, null)
+        assertNull(andesButton.rightIconComponent.drawable)
+        val drawable = IconProvider(context)
+            .loadIcon("andes_ui_placeholder_imagen_24") as BitmapDrawable
+        andesButton.setIconDrawable(drawable, AndesButtonIconOrientation.RIGHT)
+        assertNotNull(andesButton.rightIconComponent.drawable)
     }
 }

--- a/components/src/test/java/com/mercadolibre/android/andesui/button/AndesButtonTest.kt
+++ b/components/src/test/java/com/mercadolibre/android/andesui/button/AndesButtonTest.kt
@@ -16,7 +16,9 @@ import com.mercadolibre.android.andesui.button.hierarchy.AndesButtonIconOrientat
 import com.mercadolibre.android.andesui.button.size.AndesButtonSize
 import com.mercadolibre.android.andesui.icons.IconProvider
 import org.assertj.core.api.Assertions.assertThat
-import org.junit.Assert.*
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertNull
 import org.junit.Before
 import org.junit.BeforeClass
 import org.junit.Test

--- a/demoapp/src/main/java/com/mercadolibre/android/andesui/demoapp/feature/ButtonShowcaseActivity.kt
+++ b/demoapp/src/main/java/com/mercadolibre/android/andesui/demoapp/feature/ButtonShowcaseActivity.kt
@@ -9,6 +9,7 @@ import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
 import android.widget.LinearLayout
+import androidx.core.content.res.ResourcesCompat
 import com.mercadolibre.android.andesui.button.AndesButton
 import com.mercadolibre.android.andesui.button.hierarchy.AndesButtonHierarchy
 import com.mercadolibre.android.andesui.button.hierarchy.AndesButtonIcon
@@ -70,6 +71,30 @@ class ButtonShowcaseActivity : AppCompatActivity() {
             andesButtonLarge.size = AndesButtonSize.SMALL
         }
 
+        val andesButtonWithLeftDrawable = AndesButton(
+            this,
+            AndesButtonSize.LARGE,
+            AndesButtonHierarchy.LOUD
+        )
+        andesButtonWithLeftDrawable.text = getString(R.string.loud_with_drawable_button_programmatic_left)
+        andesButtonWithLeftDrawable.setOnClickListener{
+            andesButtonWithLeftDrawable.setIconDrawable(
+                ResourcesCompat.getDrawable(resources, R.drawable.andesui_icon_dynamic, null)!!,
+                AndesButtonIconOrientation.LEFT)
+        }
+
+        val andesButtonWithRightDrawable = AndesButton(
+            this,
+            AndesButtonSize.LARGE,
+            AndesButtonHierarchy.QUIET
+        )
+        andesButtonWithRightDrawable.text = getString(R.string.loud_with_drawable_button_programmatic_right)
+        andesButtonWithRightDrawable.setOnClickListener{
+            andesButtonWithRightDrawable.setIconDrawable(
+                ResourcesCompat.getDrawable(resources, R.drawable.andesui_icon_dynamic, null)!!,
+                AndesButtonIconOrientation.RIGHT)
+        }
+
         val params = LinearLayout.LayoutParams(
             LinearLayout.LayoutParams.WRAP_CONTENT,
             LinearLayout.LayoutParams.WRAP_CONTENT
@@ -79,11 +104,15 @@ class ButtonShowcaseActivity : AppCompatActivity() {
         andesButtonLarge.layoutParams = params
         andesButtonMedium.layoutParams = params
         andesButtonSmall.layoutParams = params
+        andesButtonWithLeftDrawable.layoutParams = params
+        andesButtonWithRightDrawable.layoutParams = params
 
         val linearLoud = container.findViewById<LinearLayout>(R.id.andes_loud_container)
         linearLoud.addView(andesButtonLarge, linearLoud.childCount - 1)
         linearLoud.addView(andesButtonMedium, linearLoud.childCount - 1)
         linearLoud.addView(andesButtonSmall, linearLoud.childCount - 1)
+        linearLoud.addView(andesButtonWithLeftDrawable, linearLoud.childCount - 1)
+        linearLoud.addView(andesButtonWithRightDrawable, linearLoud.childCount - 1)
 
         bindAndesSpecsButton(container)
     }
@@ -117,6 +146,31 @@ class ButtonShowcaseActivity : AppCompatActivity() {
             andesButtonLarge.text = getString(R.string.quiet_large_button_hierarchy_updated)
         }
 
+        val andesButtonWithLeftDrawable = AndesButton(
+            this,
+            AndesButtonSize.LARGE,
+            AndesButtonHierarchy.QUIET
+        )
+        andesButtonWithLeftDrawable.text = getString(R.string.loud_with_drawable_button_programmatic_left)
+        andesButtonWithLeftDrawable.setOnClickListener{
+            andesButtonWithLeftDrawable.setIconDrawable(
+                ResourcesCompat.getDrawable(resources, R.drawable.andesui_icon_dynamic, null)!!,
+                AndesButtonIconOrientation.LEFT)
+        }
+
+
+        val andesButtonWithRightDrawable = AndesButton(
+            this,
+            AndesButtonSize.LARGE,
+            AndesButtonHierarchy.QUIET
+        )
+        andesButtonWithRightDrawable.text = getString(R.string.loud_with_drawable_button_programmatic_right)
+        andesButtonWithRightDrawable.setOnClickListener{
+            andesButtonWithRightDrawable.setIconDrawable(
+                ResourcesCompat.getDrawable(resources, R.drawable.andesui_icon_dynamic, null)!!,
+                AndesButtonIconOrientation.RIGHT)
+        }
+
         val params = LinearLayout.LayoutParams(
             LinearLayout.LayoutParams.WRAP_CONTENT,
             LinearLayout.LayoutParams.WRAP_CONTENT
@@ -126,11 +180,15 @@ class ButtonShowcaseActivity : AppCompatActivity() {
         andesButtonLarge.layoutParams = params
         andesButtonMedium.layoutParams = params
         andesButtonSmall.layoutParams = params
+        andesButtonWithLeftDrawable.layoutParams = params
+        andesButtonWithRightDrawable.layoutParams = params
 
         val linearQuiet = container.findViewById<LinearLayout>(R.id.andes_quiet_container)
         linearQuiet.addView(andesButtonLarge, linearQuiet.childCount - 1)
         linearQuiet.addView(andesButtonMedium, linearQuiet.childCount - 1)
         linearQuiet.addView(andesButtonSmall, linearQuiet.childCount - 1)
+        linearQuiet.addView(andesButtonWithLeftDrawable, linearQuiet.childCount - 1)
+        linearQuiet.addView(andesButtonWithRightDrawable, linearQuiet.childCount - 1)
 
         bindAndesSpecsButton(container)
     }
@@ -167,6 +225,30 @@ class ButtonShowcaseActivity : AppCompatActivity() {
         )
         andesButtonLargeInt.text = getString(R.string.transparent_large_button_programmatic_int)
 
+        val andesButtonWithLeftDrawable = AndesButton(
+            this,
+            AndesButtonSize.LARGE,
+            AndesButtonHierarchy.TRANSPARENT
+        )
+        andesButtonWithLeftDrawable.text = getString(R.string.loud_with_drawable_button_programmatic_left)
+        andesButtonWithLeftDrawable.setOnClickListener{
+            andesButtonWithLeftDrawable.setIconDrawable(
+                ResourcesCompat.getDrawable(resources, R.drawable.andesui_icon_dynamic, null)!!,
+                AndesButtonIconOrientation.LEFT)
+        }
+
+        val andesButtonWithRightDrawable = AndesButton(
+            this,
+            AndesButtonSize.LARGE,
+            AndesButtonHierarchy.TRANSPARENT
+        )
+        andesButtonWithRightDrawable.text = getString(R.string.loud_with_drawable_button_programmatic_right)
+        andesButtonWithRightDrawable.setOnClickListener{
+            andesButtonWithRightDrawable.setIconDrawable(
+                ResourcesCompat.getDrawable(resources, R.drawable.andesui_icon_dynamic, null)!!,
+                AndesButtonIconOrientation.RIGHT)
+        }
+
         val params = LinearLayout.LayoutParams(
             LinearLayout.LayoutParams.WRAP_CONTENT,
             LinearLayout.LayoutParams.WRAP_CONTENT
@@ -176,12 +258,16 @@ class ButtonShowcaseActivity : AppCompatActivity() {
         andesButtonLarge.layoutParams = params
         andesButtonMedium.layoutParams = params
         andesButtonSmall.layoutParams = params
+        andesButtonWithLeftDrawable.layoutParams = params
+        andesButtonWithRightDrawable.layoutParams = params
 
         val linearTransparent = container.findViewById<LinearLayout>(R.id.andes_transparent_container)
         linearTransparent.addView(andesButtonLargeInt, linearTransparent.childCount - 1)
         linearTransparent.addView(andesButtonLarge, linearTransparent.childCount - 1)
         linearTransparent.addView(andesButtonMedium, linearTransparent.childCount - 1)
         linearTransparent.addView(andesButtonSmall, linearTransparent.childCount - 1)
+        linearTransparent.addView(andesButtonWithLeftDrawable, linearTransparent.childCount - 1)
+        linearTransparent.addView(andesButtonWithRightDrawable, linearTransparent.childCount - 1)
 
         bindAndesSpecsButton(container)
     }

--- a/demoapp/src/main/java/com/mercadolibre/android/andesui/demoapp/feature/ButtonShowcaseActivity.kt
+++ b/demoapp/src/main/java/com/mercadolibre/android/andesui/demoapp/feature/ButtonShowcaseActivity.kt
@@ -77,11 +77,9 @@ class ButtonShowcaseActivity : AppCompatActivity() {
             AndesButtonHierarchy.LOUD
         )
         andesButtonWithLeftDrawable.text = getString(R.string.loud_with_drawable_button_programmatic_left)
-        andesButtonWithLeftDrawable.setOnClickListener{
-            andesButtonWithLeftDrawable.setIconDrawable(
-                ResourcesCompat.getDrawable(resources, R.drawable.andesui_icon_dynamic, null)!!,
-                AndesButtonIconOrientation.LEFT)
-        }
+        andesButtonWithLeftDrawable.setIconDrawable(
+            ResourcesCompat.getDrawable(resources, R.drawable.andesui_icon_dynamic, null)!!,
+            AndesButtonIconOrientation.LEFT)
 
         val andesButtonWithRightDrawable = AndesButton(
             this,
@@ -89,10 +87,8 @@ class ButtonShowcaseActivity : AppCompatActivity() {
             AndesButtonHierarchy.QUIET
         )
         andesButtonWithRightDrawable.text = getString(R.string.loud_with_drawable_button_programmatic_right)
-        andesButtonWithRightDrawable.setOnClickListener{
-            andesButtonWithRightDrawable.setIconDrawable(
-                ResourcesCompat.getDrawable(resources, R.drawable.andesui_icon_dynamic, null)!!,
-                AndesButtonIconOrientation.RIGHT)
+        ResourcesCompat.getDrawable(resources, R.drawable.andesui_icon_dynamic, null)?.also {
+            andesButtonWithRightDrawable.setIconDrawable(it, AndesButtonIconOrientation.RIGHT)
         }
 
         val params = LinearLayout.LayoutParams(
@@ -152,10 +148,8 @@ class ButtonShowcaseActivity : AppCompatActivity() {
             AndesButtonHierarchy.QUIET
         )
         andesButtonWithLeftDrawable.text = getString(R.string.loud_with_drawable_button_programmatic_left)
-        andesButtonWithLeftDrawable.setOnClickListener{
-            andesButtonWithLeftDrawable.setIconDrawable(
-                ResourcesCompat.getDrawable(resources, R.drawable.andesui_icon_dynamic, null)!!,
-                AndesButtonIconOrientation.LEFT)
+        ResourcesCompat.getDrawable(resources, R.drawable.andesui_icon_dynamic, null)?.also {
+            andesButtonWithLeftDrawable.setIconDrawable(it, AndesButtonIconOrientation.LEFT)
         }
 
 
@@ -165,11 +159,10 @@ class ButtonShowcaseActivity : AppCompatActivity() {
             AndesButtonHierarchy.QUIET
         )
         andesButtonWithRightDrawable.text = getString(R.string.loud_with_drawable_button_programmatic_right)
-        andesButtonWithRightDrawable.setOnClickListener{
-            andesButtonWithRightDrawable.setIconDrawable(
-                ResourcesCompat.getDrawable(resources, R.drawable.andesui_icon_dynamic, null)!!,
-                AndesButtonIconOrientation.RIGHT)
+        ResourcesCompat.getDrawable(resources, R.drawable.andesui_icon_dynamic, null)?.also {
+            andesButtonWithRightDrawable.setIconDrawable(it, AndesButtonIconOrientation.RIGHT)
         }
+
 
         val params = LinearLayout.LayoutParams(
             LinearLayout.LayoutParams.WRAP_CONTENT,
@@ -231,10 +224,8 @@ class ButtonShowcaseActivity : AppCompatActivity() {
             AndesButtonHierarchy.TRANSPARENT
         )
         andesButtonWithLeftDrawable.text = getString(R.string.loud_with_drawable_button_programmatic_left)
-        andesButtonWithLeftDrawable.setOnClickListener{
-            andesButtonWithLeftDrawable.setIconDrawable(
-                ResourcesCompat.getDrawable(resources, R.drawable.andesui_icon_dynamic, null)!!,
-                AndesButtonIconOrientation.LEFT)
+        ResourcesCompat.getDrawable(resources, R.drawable.andesui_icon_dynamic, null)?.also {
+            andesButtonWithLeftDrawable.setIconDrawable(it,AndesButtonIconOrientation.LEFT)
         }
 
         val andesButtonWithRightDrawable = AndesButton(
@@ -243,10 +234,8 @@ class ButtonShowcaseActivity : AppCompatActivity() {
             AndesButtonHierarchy.TRANSPARENT
         )
         andesButtonWithRightDrawable.text = getString(R.string.loud_with_drawable_button_programmatic_right)
-        andesButtonWithRightDrawable.setOnClickListener{
-            andesButtonWithRightDrawable.setIconDrawable(
-                ResourcesCompat.getDrawable(resources, R.drawable.andesui_icon_dynamic, null)!!,
-                AndesButtonIconOrientation.RIGHT)
+        ResourcesCompat.getDrawable(resources, R.drawable.andesui_icon_dynamic, null)?.also {
+            andesButtonWithRightDrawable.setIconDrawable(it, AndesButtonIconOrientation.RIGHT)
         }
 
         val params = LinearLayout.LayoutParams(

--- a/demoapp/src/main/res/raw/andesui_demoapp_changelog.md
+++ b/demoapp/src/main/res/raw/andesui_demoapp_changelog.md
@@ -1,3 +1,7 @@
+# v3.6.0
+### 🚀 Feature
+- AndesButton With Drawable support | Authors [a0zamora](https://github.com/a0zamora)
+
 # v3.5.1
 ## 🛠 Fixes
 - Datepicker accent color

--- a/demoapp/src/main/res/raw/andesui_demoapp_changelog.md
+++ b/demoapp/src/main/res/raw/andesui_demoapp_changelog.md
@@ -6,6 +6,9 @@
 ### 🚀 Feature
 - AndesMessage With Thumbnnail | Authors [a0zamora](https://github.com/a0zamora)
 
+### ⚙️ Other
+- Disable bot for issues | Authors [joalonspint](https://github.com/joalonsopint)
+
 # v3.4.0
 ## 🚀 Features
 - Dropdown | Author: [@snti](https://github.com/snti)

--- a/demoapp/src/main/res/raw/andesui_demoapp_changelog.md
+++ b/demoapp/src/main/res/raw/andesui_demoapp_changelog.md
@@ -1,17 +1,13 @@
 # v3.6.0
-### 🚀 Feature
+## 🚀 Feature
 - AndesButton With Drawable support | Authors [a0zamora](https://github.com/a0zamora)
 
-# v3.5.1
 ## 🛠 Fixes
 - Datepicker accent color
 
 # v3.5.0
-### 🚀 Feature
+## 🚀 Feature
 - AndesMessage With Thumbnnail | Authors [a0zamora](https://github.com/a0zamora)
-
-### ⚙️ Other
-- Disable bot for issues | Authors [joalonspint](https://github.com/joalonsopint)
 
 # v3.4.0
 ## 🚀 Features

--- a/demoapp/src/main/res/values/strings.xml
+++ b/demoapp/src/main/res/values/strings.xml
@@ -7,6 +7,8 @@
     <string name="loud_small_loading_button">Loading Loud Small Button</string>
     <string name="loud_large_button_programmatic">Loud Large Button Programmatic</string>
     <string name="loud_medium_button_programmatic">Loud Medium Button Programmatic</string>
+    <string name="loud_with_drawable_button_programmatic_left">Loud With Drawable Left</string>
+    <string name="loud_with_drawable_button_programmatic_right">Loud With Drawable Right</string>
     <string name="loud_small_button_programmatic">Loud Small Button Programmatic disabled</string>
     <string name="loud_large_button_disabled">Loud large button disabled</string>
     <string name="loud_large_button_text_updated">This text was updated programmatically</string>

--- a/gradle.properties
+++ b/gradle.properties
@@ -38,7 +38,7 @@ libraryGroupId=com.mercadolibre.android.andesui
 # IMPORTANT: We're using http://semver.org/ for all Android projects, please remember to follow this convention.
 # IMPORTANT: The version will be THE SAME for all modules.
 # For libraryVersion do NOT add a qualifier to this version like LOCAL/EXPERIMENTAL (it'll be added automatically!)
-libraryVersion=3.5.1
+libraryVersion=3.6.0
 
 ##################################################################################
 # Project setup


### PR DESCRIPTION
## Description
This new feature allows the user to set a Drawable programmatically.


## Affected component
AndesButton


## Screenshots
![2021-01-20 14 06 43](https://user-images.githubusercontent.com/13289298/105209571-c19c5680-5b28-11eb-974a-51be1f4acf37.gif)




## Checks
Are you sure you followed all those steps? In such case, let's say with me "I solemnly declare that ...":
- [x] I have coded an example inside the Demo App,
- [x] I have added proper tests,
- [x] I have modified the [Changelog](https://github.com/mercadolibre/fury_andesui-android/blob/develop/CHANGELOG.md) file,
- [ ] I have updated GitHub wiki,
- [ ] I have the explicit approval of one or more members of the UX Team,
- [x] I have updated the version in gradle.properties file.

## Change type
This is easy, let us know what this code is about:
- [ ] This code adds a new component
- [x] This code includes improvements to an existent component
- [ ] This code improves or modifies ONLY the Demo App.

