### PR TITLE
accessibility scrolless coachmark

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 - Added new icons for "To Agree" and "Info" (with outer circle)
 
 ## 🛠 Fixes
-- Demoapp dropdown showcase scrollview container added to avoid cutting content
+- Demoapp Dropdown activity scrollview container added to avoid cutting content
 - Demoapp thumbnail showcase with same resource id as component fixed
 - Dropdown label deleted in standalone type | Author: [@snti](https://github.com/snti)
 

--- a/coachmark/src/main/java/com/mercadolibre/android/andesui/coachmark/view/walkthroughscrolless/CoachmarkScrollessView.kt
+++ b/coachmark/src/main/java/com/mercadolibre/android/andesui/coachmark/view/walkthroughscrolless/CoachmarkScrollessView.kt
@@ -15,6 +15,7 @@ import android.view.WindowManager
 import android.widget.FrameLayout
 import androidx.core.content.ContextCompat
 import androidx.core.view.ViewCompat
+import androidx.core.view.ViewPropertyAnimatorListener
 import androidx.core.view.ViewPropertyAnimatorListenerAdapter
 import androidx.recyclerview.widget.RecyclerView
 import com.mercadolibre.android.andesui.coachmark.CoachmarkTracking
@@ -94,6 +95,20 @@ class CoachmarkScrollessView private constructor(builder: Builder) : CoachmarkVi
         ViewCompat.animate(baseContainer)
                 .alpha(1f)
                 .setDuration(ANIMATION_OVERLAY_DURATION)
+                .setListener(object : ViewPropertyAnimatorListener {
+                    override fun onAnimationEnd(view: View?) {
+                        // needed for accessibility
+                        coachmarkContainer.requestFocus()
+                    }
+
+                    override fun onAnimationCancel(view: View?) {
+                        // no-op
+                    }
+
+                    override fun onAnimationStart(view: View?) {
+                        // no-op
+                    }
+                })
                 .start()
     }
 

--- a/coachmark/src/main/res/layout/andes_walkthrough_scrolless_container.xml
+++ b/coachmark/src/main/res/layout/andes_walkthrough_scrolless_container.xml
@@ -3,6 +3,8 @@
     xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
     xmlns:tools="http://schemas.android.com/tools"
+    android:focusable="true"
+    android:focusableInTouchMode="true"
     android:layout_width="match_parent"
     android:layout_height="match_parent">
 
@@ -41,6 +43,7 @@
         app:layout_constraintBottom_toTopOf="@id/guideLineHeader"
         app:layout_constraintStart_toStartOf="parent"
         app:layout_constraintTop_toBottomOf="@id/guideLineStatusBar"
+        android:importantForAccessibility="no"
         tools:text="1 de 3" />
 
     <TextView
@@ -64,6 +67,7 @@
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintTop_toBottomOf="@id/guideLineStatusBar"
         app:srcCompat="@drawable/andes_ui_close_24"
+        android:contentDescription="@android:string/cancel"
         app:tint="@color/andes_white" />
 
     <ImageView
@@ -74,6 +78,7 @@
         app:layout_constraintBottom_toTopOf="@id/guideLineHeader"
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintTop_toBottomOf="@id/guideLineStatusBar"
+        android:importantForAccessibility="no"
         app:tint="@color/andes_white" />
 
     <com.mercadolibre.android.andesui.coachmark.view.CoachmarkOverlay

--- a/coachmark/src/main/res/layout/andes_walkthrough_scrolless_message.xml
+++ b/coachmark/src/main/res/layout/andes_walkthrough_scrolless_message.xml
@@ -22,6 +22,7 @@
             app:layout_constraintEnd_toEndOf="parent"
             app:layout_constraintStart_toStartOf="parent"
             app:layout_constraintTop_toTopOf="parent"
+            android:importantForAccessibility="no"
             tools:visibility="visible" />
 
         <TextView
@@ -91,6 +92,7 @@
             app:layout_constraintEnd_toEndOf="parent"
             app:layout_constraintStart_toStartOf="parent"
             app:layout_constraintTop_toBottomOf="@id/walkthroughDescription"
+            android:importantForAccessibility="no"
             tools:visibility="visible" />
 
     </androidx.constraintlayout.widget.ConstraintLayout>

--- a/demoapp/src/main/res/raw/andesui_demoapp_changelog.md
+++ b/demoapp/src/main/res/raw/andesui_demoapp_changelog.md
@@ -3,7 +3,7 @@
 - Added new icons for "To Agree" and "Info" (with outer circle)
 
 ## 🛠 Fixes
-- Demoapp Dropdown activity scrollview container added to avoid cutting content
+- Demoapp dropdown showcase scrollview container added to avoid cutting content
 - Demoapp thumbnail showcase with same resource id as component fixed
 - Dropdown label deleted in standalone type | Author: [@snti](https://github.com/snti)
 


### PR DESCRIPTION
### Thanks for starting a pull request on Andes UI!

## Motivation
Se realizaron modificaciones basicas para permitir la navegacion. 
- Se hace foco en el coachmark
- Se marcan las flechas como no importantes para talkback.
- Se agrega etiqueta al boton que permite cerrar el coahmark.


## Affected component
Is highly probable that this new code directly affects one (or more?) components inside this lib. Tell us who they are!

## Frontify component link
The UX team behind Andes keeps all the Andes Components inside the Frontify site. Each component has its own section. Let us know the section of the component you want to modify.

## Screenshots
This is a UI library, delight us with some stunning images.


## Checks
Are you sure you followed all those steps? In such case, let's say with me "I solemnly declare that ...":
- [ ] I have coded an example inside the Demo App,
- [ ] I have added proper tests,
- [ ] I have modified the [Changelog](https://github.com/mercadolibre/fury_andesui-android/blob/develop/CHANGELOG.md) file,
- [ ] I have updated GitHub wiki,
- [ ] I have the explicit approval of one or more members of the UX Team,
- [ ] I have updated the version in gradle.properties file.

## Change type
This is easy, let us know what this code is about:
- [ ] This code adds a new component
- [ ] This code includes improvements to an existent component
- [ ] This code improves or modifies ONLY the Demo App.

## Check common errors
Whether you are an Android or iOS developer and if you're still there then we'll give you a present:
https://proandroiddev.com/how-to-maximize-androids-ui-reusability-5-common-mistakes-cb2571216a9f
